### PR TITLE
Issue #14, issue #7 and namespace corrections

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,16 @@
 ## What's changed
 <!-- Give a concise description of the change -->
+- For Logical Views: changed `rml:onLogicalSource` and `rml:source` to `rml:viewOn`
+- For Input Logical Sources: changed `rml:LogicalSource` to `rml:InputLogicalSource` 
 
 ## Change checklist
-- [ ] updated ontology, where necessary
-- [ ] updated shapes, where necessary
-- [ ] added or updated test cases, where necessary
-- [ ] any TODOs have been turned into trackable issues and referenced where necessary
+- [x] updated ontology, where necessary
+- [x] updated shapes, where necessary
+- [x] added or updated test cases, where necessary
+- [x] any TODOs have been turned into trackable issues and referenced where necessary
 
 ## Issue reference
 <!-- For example: -->
 <!-- Fixes #{ISSUE}. -->
 <!-- Resolves #{ISSUE}. -->
+Fixes #14 and #7.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,13 @@
 ## What's changed
 <!-- Give a concise description of the change -->
-- For Logical Views: changed `rml:onLogicalSource` and `rml:source` to `rml:viewOn`
-- For Input Logical Sources: changed `rml:LogicalSource` to `rml:InputLogicalSource` 
 
 ## Change checklist
-- [x] updated ontology, where necessary
-- [x] updated shapes, where necessary
-- [x] added or updated test cases, where necessary
-- [x] any TODOs have been turned into trackable issues and referenced where necessary
+- [ ] updated ontology, where necessary
+- [ ] updated shapes, where necessary
+- [ ] added or updated test cases, where necessary
+- [ ] any TODOs have been turned into trackable issues and referenced where necessary
 
 ## Issue reference
 <!-- For example: -->
 <!-- Fixes #{ISSUE}. -->
 <!-- Resolves #{ISSUE}. -->
-Fixes #14 and #7.

--- a/ontology/documentation/ontology.ttl
+++ b/ontology/documentation/ontology.ttl
@@ -30,11 +30,13 @@ rml:field rdf:type owl:ObjectProperty ;
           rdfs:range rml:Field ;
           rdfs:isDefinedBy <http://w3id.org/rml/lv/> .
 
+
 ### http://w3id.org/rml/viewOn
 rml:viewOn rdf:type owl:ObjectProperty ;
-          rdfs:domain :LogicalView ;
-          rdfs:range :LogicalSource ;
+          rdfs:domain rml:LogicalView ;
+          rdfs:range rml:LogicalSource ;
           rdfs:isDefinedBy <http://w3id.org/rml/lv/> .
+
 
 ###  http://w3id.org/rml/innerJoin
 rml:innerJoin rdf:type owl:ObjectProperty ;
@@ -57,29 +59,31 @@ rml:parentLogicalView rdf:type owl:ObjectProperty ;
                       rdfs:isDefinedBy <http://w3id.org/rml/lv/> .
 
 
-###  http://w3id.org/rml/lv/onFields
-:onFields rdf:type owl:ObjectProperty ;
-          rdfs:domain :StructuralAnnotation ;
+###  http://w3id.org/rml/onFields
+rml:onFields rdf:type owl:ObjectProperty ;
+          rdfs:domain rml:StructuralAnnotation ;
           rdfs:range rdf:List ;
-          rdfs:comment "" .
+          rdfs:isDefinedBy <http://w3id.org/rml/lv/> .
 
 
-###  http://w3id.org/rml/lv/structuralAnnotation
-:structuralAnnotation rdf:type owl:ObjectProperty ;
+###  http://w3id.org/rml/structuralAnnotation
+rml:structuralAnnotation rdf:type owl:ObjectProperty ;
                       rdfs:domain rml:LogicalView ;
-                      rdfs:range :StructuralAnnotation .
+                      rdfs:range rml:StructuralAnnotation ;
+                      rdfs:isDefinedBy <http://w3id.org/rml/lv/> .
+
+###  http://w3id.org/rml/targetFields
+rml:targetFields rdf:type owl:ObjectProperty ;
+              rdfs:domain rml:StructuralAnnotation ;
+              rdfs:range rdf:List ;
+              rdfs:isDefinedBy <http://w3id.org/rml/lv/> .
 
 
-###  http://w3id.org/rml/lv/targetFields
-:targetFields rdf:type owl:ObjectProperty ;
-              rdfs:domain :StructuralAnnotation ;
-              rdfs:range rdf:List .
-
-
-###  http://w3id.org/rml/lv/targetView
-:targetView rdf:type owl:ObjectProperty ;
-            rdfs:domain :InclusionDependencyAnnotation ;
-            rdfs:range rml:LogicalView .
+###  http://w3id.org/rml/targetView
+rml:targetView rdf:type owl:ObjectProperty ;
+            rdfs:domain rml:InclusionDependencyAnnotation ;
+            rdfs:range rml:LogicalView ;
+            rdfs:isDefinedBy <http://w3id.org/rml/lv/> .
 
 
 #################################################################
@@ -115,39 +119,46 @@ rml:LogicalViewJoin rdf:type owl:Class ;
                     rdfs:isDefinedBy <http://w3id.org/rml/lv/> .
 
 
-###  http://w3id.org/rml/lv/ForeignKeyAnnotation
-:ForeignKeyAnnotation rdf:type owl:Class ;
-                      rdfs:subClassOf :InclusionDependencyAnnotation .
+###  http://w3id.org/rml/ForeignKeyAnnotation
+rml:ForeignKeyAnnotation rdf:type owl:Class ;
+                      rdfs:subClassOf rml:InclusionDependencyAnnotation ;
+                      rdfs:isDefinedBy <http://w3id.org/rml/lv/> .
 
 
-###  http://w3id.org/rml/lv/IRISafeAnnotation
-:IRISafeAnnotation rdf:type owl:Class ;
-                   rdfs:subClassOf :StructuralAnnotation .
+###  http://w3id.org/rml/IRISafeAnnotation
+rml:IRISafeAnnotation rdf:type owl:Class ;
+                   rdfs:subClassOf rml:StructuralAnnotation ;
+                   rdfs:isDefinedBy <http://w3id.org/rml/lv/> .
 
 
-###  http://w3id.org/rml/lv/InclusionDependencyAnnotation
-:InclusionDependencyAnnotation rdf:type owl:Class ;
-                               rdfs:subClassOf :StructuralAnnotation .
+###  http://w3id.org/rml/InclusionDependencyAnnotation
+rml:InclusionDependencyAnnotation rdf:type owl:Class ;
+                               rdfs:subClassOf rml:StructuralAnnotation ;
+                               rdfs:isDefinedBy <http://w3id.org/rml/lv/> .
 
 
-###  http://w3id.org/rml/lv/NonNullableAnnotation
-:NonNullableAnnotation rdf:type owl:Class ;
-                       rdfs:subClassOf :StructuralAnnotation .
+###  http://w3id.org/rml/NonNullableAnnotation
+rml:NonNullableAnnotation rdf:type owl:Class ;
+                       rdfs:subClassOf rml:StructuralAnnotation ;
+                       rdfs:isDefinedBy <http://w3id.org/rml/lv/> .
 
 
-###  http://w3id.org/rml/lv/PrimaryKeyAnnotation
-:PrimaryKeyAnnotation rdf:type owl:Class ;
-                      rdfs:subClassOf :NonNullableAnnotation ,
-                                      :UniqueAnnotation .
+###  http://w3id.org/rml/PrimaryKeyAnnotation
+rml:PrimaryKeyAnnotation rdf:type owl:Class ;
+                      rdfs:subClassOf rml:NonNullableAnnotation ,
+                                      rml:UniqueAnnotation ;
+                      rdfs:isDefinedBy <http://w3id.org/rml/lv/> .
 
 
-###  http://w3id.org/rml/lv/StructuralAnnotation
-:StructuralAnnotation rdf:type owl:Class .
+###  http://w3id.org/rml/StructuralAnnotation
+rml:StructuralAnnotation rdf:type owl:Class ;
+                      rdfs:isDefinedBy <http://w3id.org/rml/lv/> .
 
 
-###  http://w3id.org/rml/lv/UniqueAnnotation
-:UniqueAnnotation rdf:type owl:Class ;
-                  rdfs:subClassOf :StructuralAnnotation .
+###  http://w3id.org/rml/UniqueAnnotation
+rml:UniqueAnnotation rdf:type owl:Class ;
+                  rdfs:subClassOf rml:StructuralAnnotation ;
+                  rdfs:isDefinedBy <http://w3id.org/rml/lv/> .
 
 
 ###  http://www.w3.org/1999/02/22-rdf-syntax-ns#List

--- a/ontology/documentation/ontology.ttl
+++ b/ontology/documentation/ontology.ttl
@@ -30,6 +30,11 @@ rml:field rdf:type owl:ObjectProperty ;
           rdfs:range rml:Field ;
           rdfs:isDefinedBy <http://w3id.org/rml/lv/> .
 
+### http://w3id.org/rml/viewOn
+rml:viewOn rdf:type owl:ObjectProperty ;
+          rdfs:domain :LogicalView ;
+          rdfs:range :LogicalSource ;
+          rdfs:isDefinedBy <http://w3id.org/rml/lv/> .
 
 ###  http://w3id.org/rml/innerJoin
 rml:innerJoin rdf:type owl:ObjectProperty ;

--- a/shapes/lv.ttl
+++ b/shapes/lv.ttl
@@ -18,7 +18,7 @@ rmlsh:LogicalViewShape a sh:NodeShape ;
     sh:message """
     Node must have a valid rml:LogicalView description.
     rml:LogicalView requires
-    - exactly one rml:source property, with a rml:LogicalSource as its value.
+    - exactly one rml:viewOn property, with a rml:LogicalSource as its value.
     - at least one rml:field property, with a rml:Field as its value.
     """ ;
     sh:targetClass rml:LogicalView ;
@@ -28,9 +28,9 @@ rmlsh:LogicalViewShape a sh:NodeShape ;
         The source of the logical view. This is the logical source from which the logical view is derived.
         """ ;
         sh:message """
-        Exactly one rml:source property must be specified for a rml:LogicalView, with a rml:LogicalSource as its value.
+        Exactly one rml:viewOn property must be specified for a rml:LogicalView, with a rml:LogicalSource as its value.
         """ ;
-        sh:path rml:source ;
+        sh:path rml:viewOn ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:node rmlsh:LogicalSource ;

--- a/spec/section/annotations.md
+++ b/spec/section/annotations.md
@@ -71,7 +71,7 @@ First, we specify the logical source corresponding to the CSV file:
 <aside class=ex-mapping>
 
 ```turtle
-:csvSource a rml:logicalSource ;
+:csvSource a rml:InputLogicalSource ;
   rml:source :csvFile ;
   rml:referenceFormulation rml:CSV .
 ```
@@ -83,7 +83,7 @@ We are now ready to specify our logical view and associated `rml:primaryKeyAnnot
 
 ```turtle
 :csvSource a rml:LogicalView ;
-  rml:onLogicalSource :csvSource ;
+  rml:viewOn :csvSource ;
   rml:field [
     rml:fieldName "name";
     rml:reference "name"
@@ -188,7 +188,7 @@ First, we need to specify the logical sources. The logical source corresponding 
 <aside class=ex-mapping>
 
 ```turtle
-:csvSource a rml:logicalSource ;
+:csvSource a rml:InputLogicalSource ;
   rml:source :csvFile ;
   rml:referenceFormulation rml:CSV .
 ```
@@ -199,7 +199,7 @@ The logical source corresponding to the JSON:
 <aside class=ex-mapping>
 
 ```turtle
-:jsonSource a rml:logicalSource ;
+:jsonSource a rml:InputLogicalSource ;
   rml:source :jsonFile ;
   rml:referenceFormulation rml:JSONPath ;
   rml:iterator "$.people[*]" .
@@ -212,7 +212,7 @@ We are now ready to specify our logical views, and associated structural annotat
 
 ```turtle
 :csvSource a rml:LogicalView ;
-  rml:onLogicalSource :csvSource ;
+  rml:viewOn :csvSource ;
   rml:field [
     rml:fieldName "name";
     rml:reference "name"
@@ -234,7 +234,7 @@ Now, we declare the logical view corresponding to `:jsonSource`. Note that this 
 
 ```turtle
 :jsonView a rml:LogicalView ;
-  rml:onLogicalSource :jsonSource ;
+  rml:viewOn :jsonSource ;
   rml:field [
     rml:fieldName "name" ;
     rml:reference "$.name" ;

--- a/spec/section/fields.md
+++ b/spec/section/fields.md
@@ -10,7 +10,7 @@ In this example a [=field=] with [=declared name=] "name" is declared on the <!-
 
 ```turtle
 :jsonView a rml:LogicalView ;
-  rml:onLogicalSource :jsonSource ;
+  rml:viewOn :jsonSource ;
   rml:field [
     rml:fieldName "name" ;
     rml:reference "$.name" ;
@@ -92,7 +92,7 @@ In this example a [=field=] with [=declared name=] "item" is added to the [=logi
 
 ```turtle
 :jsonView a rml:LogicalView ;
-  rml:onLogicalSource :jsonSource ;
+  rml:viewOn :jsonSource ;
   rml:field [
     rml:fieldName "name" ;
     rml:reference "$.name" ;
@@ -264,7 +264,7 @@ A [=field reference=] can be used in <a data-cite="RML-Core#dfn-expression-map">
 
 ```turtle
 :jsonView a rml:LogicalView ;
-  rml:onLogicalSource :jsonSource ;
+  rml:viewOn :jsonSource ;
   rml:field [
     rml:fieldName "name" ;
     rml:reference "$.name" ;

--- a/spec/section/records.md
+++ b/spec/section/records.md
@@ -20,7 +20,7 @@ tobias,2005
 <aside class=ex-mapping>
 
 ```turtle
-:csvSource a rml:logicalSource ;
+:csvSource a rml:InputLogicalSource ;
   rml:source :csvFile ;
   rml:referenceFormulation rml:CSV .
 ```
@@ -71,7 +71,7 @@ tobias,2005
 <aside class=ex-mapping>
 
 ```turtle
-:xmlSource a rml:logicalSource ;
+:xmlSource a rml:InputLogicalSource ;
   rml:source :xmlFile ;
   rml:referenceFormulation rml:XPath ;
   rml:iterator "/People/Person" .
@@ -141,7 +141,7 @@ and
 <aside class=ex-mapping>
 
 ```turtle
-:jsonSource a rml:logicalSource ;
+:jsonSource a rml:InputLogicalSource ;
   rml:source :jsonFile ;
   rml:referenceFormulation rml:JSONPath ;
   rml:iterator "$.people[*]" .
@@ -272,7 +272,7 @@ An <!-- TODO core or io, dependent on https://github.com/kg-construct/rml-lv/iss
 <aside class=ex-mapping>
 
 ```turtle
-:jsonSource a rml:logicalSource ;
+:jsonSource a rml:InputLogicalSource ;
   rml:source :jsonFile ;
   rml:referenceFormulation rml:JSONPath ;
   rml:iterator "$.people[*]" .

--- a/spec/section/views.md
+++ b/spec/section/views.md
@@ -3,7 +3,7 @@
 A <dfn>logical view</dfn> (`rml:LogicalView`) is a type of <!-- TODO link to logical source definition in IO? raise issue -->logical source that is derived from another <!-- TODO core or io, dependent on https://github.com/kg-construct/rml-lv/issues/7 and https://github.com/kg-construct/rml-lv/issues/14-->logical source by defining [=fields=] with data from said <!-- TODO io -->logical source.
 
 A [=logical view=] (`rml:LogicalView`) is represented by a resource that MUST contain:
-- exactly one <!-- TODO core or io, dependent on https://github.com/kg-construct/rml-lv/issues/7 and https://github.com/kg-construct/rml-lv/issues/14-->source property (`rml:source`), whose value is a <!-- TODO core or io, dependent on https://github.com/kg-construct/rml-lv/issues/7 and https://github.com/kg-construct/rml-lv/issues/14-->[logical source](https://kg-construct.github.io/rml-io/spec/docs/#source-vocabulary) (`rml:LogicalSource`),
+- exactly one <!-- TODO core or io, dependent on https://github.com/kg-construct/rml-lv/issues/7 and https://github.com/kg-construct/rml-lv/issues/14-->source property (`rml:viewOn`), whose value is a <!-- TODO core or io, dependent on https://github.com/kg-construct/rml-lv/issues/7 and https://github.com/kg-construct/rml-lv/issues/14-->[logical source](https://kg-construct.github.io/rml-io/spec/docs/#source-vocabulary) (`rml:LogicalSource`),
 - at least one field property (`rml:field`), whose value is a [=field=] (`rml:Field`).
 - zero or more join properties (`rml:leftJoin`, `rml:innerJoin`) to describe a [=logical view join=] operation (`rml:LogicalViewJoin`) with another [=Logical View=].
 
@@ -11,7 +11,7 @@ A [=logical view=] (`rml:LogicalView`) has an implicit default <!-- TODO core or
 
 | Property              | Domain             | Range                 |
 |-----------------------|--------------------|-----------------------|
-| `rml:onLogicalSource` | `rml:LogicalView`  | `rml:LogicalSource`   |
+| `rml:viewOn` | `rml:LogicalView`  | `rml:LogicalSource`   |
 | `rml:field`           |                    | `rml:Field`           |
 | `rml:leftJoin`        | `rml:LogicalView`  | `rml:LogicalViewJoin` |
 | `rml:innerJoin`       | `rml:LogicalView`  | `rml:LogicalViewJoin` |

--- a/test-cases/RMLLVTC0001/mapping.ttl
+++ b/test-cases/RMLLVTC0001/mapping.ttl
@@ -1,7 +1,7 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix : <http://example.org/> .
 
-:jsonSource a rml:LogicalSource ;
+:jsonSource a rml:InputLogicalSource ;
   rml:source [
     a rml:RelativePathSource , rml:Source ;
     rml:root rml:MappingDirectory ;
@@ -11,7 +11,7 @@
   rml:iterator "$.people[*]" .
 
 :jsonView a rml:LogicalView ;
-  rml:source :jsonSource ;
+  rml:viewOn :jsonSource ;
   rml:field [
     rml:fieldName "name" ;
     rml:reference "$.name" ;

--- a/test-cases/RMLLVTC0002/mapping.ttl
+++ b/test-cases/RMLLVTC0002/mapping.ttl
@@ -2,7 +2,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix : <http://example.org/> .
 
-:jsonSource a rml:LogicalSource ;
+:jsonSource a rml:InputLogicalSource ;
   rml:source [
     a rml:RelativePathSource , rml:Source ;
     rml:root rml:MappingDirectory ;
@@ -12,7 +12,7 @@
   rml:iterator "$.people[*]" .
 
 :jsonView a rml:LogicalView ;
-  rml:source :jsonSource ;
+  rml:viewOn :jsonSource ;
   rml:field [
     rml:fieldName "name" ;
     rml:reference "$.name" ;

--- a/test-cases/RMLLVTC0003/mapping.ttl
+++ b/test-cases/RMLLVTC0003/mapping.ttl
@@ -2,7 +2,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix : <http://example.org/> .
 
-:jsonSource a rml:LogicalSource ;
+:jsonSource a rml:InputLogicalSource ;
   rml:source [
     a rml:RelativePathSource , rml:Source ;
     rml:root rml:MappingDirectory ;
@@ -12,7 +12,7 @@
   rml:iterator "$.people[*]" .
 
 :jsonView a rml:LogicalView ;
-  rml:source :jsonSource ;
+  rml:viewOn :jsonSource ;
   rml:field [
     rml:fieldName "name" ;
     rml:reference "$.name" ;
@@ -30,7 +30,7 @@
     ] ;
   ] .
 
-:csvSource a rml:LogicalSource ;
+:csvSource a rml:InputLogicalSource ;
   rml:source [
     a rml:RelativePathSource , rml:Source ;
     rml:root rml:MappingDirectory ;
@@ -39,7 +39,7 @@
   rml:referenceFormulation rml:CSV .
 
 :csvView a rml:LogicalView ;
-  rml:source :csvSource ;
+  rml:viewOn :csvSource ;
   rml:field [
     rml:fieldName "name" ;
     rml:reference "name" ;
@@ -53,7 +53,7 @@
     rml:joinCondition [
       rml:parent "name" ;
       rml:child "name" ;
-    ] ; 
+    ] ;
     rml:field [
       rml:fieldName "item_type" ;
       rml:reference "item.type" ;

--- a/test-cases/RMLLVTC0004/mapping.ttl
+++ b/test-cases/RMLLVTC0004/mapping.ttl
@@ -2,7 +2,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix : <http://example.org/> .
 
-:jsonSource a rml:LogicalSource ;
+:jsonSource a rml:InputLogicalSource ;
   rml:source [
     a rml:RelativePathSource , rml:Source ;
     rml:root rml:MappingDirectory ;
@@ -12,7 +12,7 @@
   rml:iterator "$.people[*]" .
 
 :jsonView a rml:LogicalView ;
-  rml:source :jsonSource ;
+  rml:viewOn :jsonSource ;
   rml:field [
     rml:fieldName "name" ;
     rml:reference "$.name" ;
@@ -30,7 +30,7 @@
     ] ;
   ] .
 
-:csvSource a rml:LogicalSource ;
+:csvSource a rml:InputLogicalSource ;
   rml:source [
     a rml:RelativePathSource , rml:Source ;
     rml:root rml:MappingDirectory ;
@@ -39,7 +39,7 @@
   rml:referenceFormulation rml:CSV .
 
 :csvView a rml:LogicalView ;
-  rml:source :csvSource ;
+  rml:viewOn :csvSource ;
   rml:field [
     rml:fieldName "name" ;
     rml:reference "name" ;

--- a/test-cases/RMLLVTC0005/mapping.ttl
+++ b/test-cases/RMLLVTC0005/mapping.ttl
@@ -2,7 +2,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix : <http://example.org/> .
 
-:jsonSource a rml:LogicalSource ;
+:jsonSource a rml:InputLogicalSource ;
   rml:source [
     a rml:RelativePathSource , rml:Source ;
     rml:root rml:MappingDirectory ;
@@ -12,7 +12,7 @@
   rml:iterator "$.people[*]" .
 
 :jsonView a rml:LogicalView ;
-  rml:source :jsonSource ;
+  rml:viewOn :jsonSource ;
   rml:field [
     rml:fieldName "name" ;
     rml:reference "$.name" ;
@@ -30,7 +30,7 @@
     ] ;
   ] .
 
-:csvSource a rml:LogicalSource ;
+:csvSource a rml:InputLogicalSource ;
   rml:source [
     a rml:RelativePathSource , rml:Source ;
     rml:root rml:MappingDirectory ;
@@ -39,7 +39,7 @@
   rml:referenceFormulation rml:CSV .
 
 :csvView a rml:LogicalView ;
-  rml:source :csvSource ;
+  rml:viewOn :csvSource ;
   rml:field [
     rml:fieldName "name" ;
     rml:reference "name" ;


### PR DESCRIPTION
## What's changed
- For Logical Views: changed `rml:onLogicalSource` and `rml:source` to `rml:viewOn`
- For Input Logical Sources: changed `rml:LogicalSource` to `rml:InputLogicalSource` 
- Namespace corrections in ontology.ttl

## Change checklist
- [x] updated ontology, where necessary
- [x] updated shapes, where necessary
- [x] added or updated test cases, where necessary
- [x] any TODOs have been turned into trackable issues and referenced where necessary

## Issue reference
Fixes #14.
Fixes #7.