### PR TITLE
replacing rml:JoinCondition by rml:Join

### DIFF
--- a/shapes/lv.ttl
+++ b/shapes/lv.ttl
@@ -150,7 +150,7 @@ rmlsh:LogicalViewJoinShape a sh:NodeShape ;
         sh:nodeKind sh:BlankNodeOrIRI ;
     ] , [
         sh:description """
-        A join condition of the logical view join.
+        A field of the logical view join.
         """ ;
         sh:message """
         At least one rml:field property must be specified for a rml:LogicalViewJoin, with a resource as its value.

--- a/spec/section/joins.md
+++ b/spec/section/joins.md
@@ -9,11 +9,11 @@ A [=logical view join=] (`rml:LogicalViewJoin`) MUST contain:
 
 The [=logical view=] in the subject position of the [=join property=], fulfills the role of <!-- TODO reference to core child logical source when available-->[child logical source]() in the <a data-cite="RML-Core#dfn-join-condition">join condition(s)</a> of the [=logical view join=], and is referred to as <dfn>child logical view</dfn>.
 
-| Property                | Domain                | Range               |
-|-------------------------|-----------------------|---------------------|
-| `rml:parentLogicalView` | `rml:LogicalViewJoin` | `rml:LogicalView`   |
-| `rml:joinCondition`     | `rml:LogicalViewJoin` | `rml:JoinCondition` |
-| `rml:field`             | `rml:LogicalViewJoin` | `rml:Field`         |
+| Property                | Domain                | Range             |
+|-------------------------|-----------------------|-------------------|
+| `rml:parentLogicalView` | `rml:LogicalViewJoin` | `rml:LogicalView` |
+| `rml:joinCondition`     | `rml:LogicalViewJoin` | `rml:Join`        |
+| `rml:field`             | `rml:LogicalViewJoin` | `rml:Field`       |
 
 ### Join types {#dfn-join-type}
 


### PR DESCRIPTION
## What's changed
<!-- Give a concise description of the change -->
The spec mentions `rml:JoinCondition` as range of `rml:joinCondition`. The correct term in RML is `rml:Join`.
## Change checklist
- [x] updated ontology, where necessary
- [x] updated shapes, where necessary
- [x] added or updated test cases, where necessary
- [x] any TODOs have been turned into trackable issues and referenced where necessary

## Issue reference
<!-- For example: -->
<!-- Fixes #{ISSUE}. -->
<!-- Resolves #{ISSUE}. -->
