### PR TITLE
adapting the publication URI of the spec

### DIFF
--- a/spec/config.js
+++ b/spec/config.js
@@ -87,22 +87,22 @@ var respecConfig = {
   ],
   // name of the WG, should be listed at https://respec.org/w3c/groups/
   group: "kg-construct",
-  latestVersion: "https://w3id.org/rml/lv/spec/",
+  latestVersion: "https://kg-construct.github.io/rml-lv/spec/docs/",
   issueBase: "https://github.com/kg-construct/rml-lv/issues",
   noRecTrack: "true",
   otherLinks: [
     {
       key: "This Version",
       data: [{
-        value: "https://w3id.org/rml/lv/spec/%thisDate%/",
-        href: "https://w3id.org/rml/lv/spec/%thisDate%/"
+        value: "https://kg-construct.github.io/rml-lv/spec/docs/%thisDate%/",
+        href: "https://kg-construct.github.io/rml-lv/spec/docs/%thisDate%/"
       }]
     },
     {
       key: "Previous Version",
       data: [{
-        value: "https://w3id.org/rml/lv/spec/%prevDate%/",
-        href: "https://w3id.org/rml/lv/spec/%prevDate%/"
+        value: "https://kg-construct.github.io/rml-lv/spec/docs/%prevDate%/",
+        href: "https://kg-construct.github.io/rml-lv/spec/docs/%prevDate%/"
       }]
     },
     {

--- a/spec/docs/20250114/index.html
+++ b/spec/docs/20250114/index.html
@@ -42,13 +42,13 @@ dfn{cursor:pointer}
 .dfn-panel li{margin-left:1em}
 .dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
 </style>
-    
+
 <title>RML Logical Views</title>
-    
-    
+
+
 <link rel="stylesheet" type="text/css" href="./20250114/resources/css/extras.css">
-    
-    
+
+
 <style type="text/css">
 
         /* Adapted from R2RML */
@@ -133,13 +133,13 @@ dfn{cursor:pointer}
         th {
           font-weight: bold;
         }
-    
+
 </style>
-    
-    
-    
+
+
+
 <script data-goatcounter="https://rml-fields.goatcounter.com/count" async="" src="//gc.zgo.at/count.js"></script>
-    
+
 <noscript>
         &lt;img src="https://rml-fields.goatcounter.com/count?p=/test-noscript"&gt;
     </noscript>
@@ -292,7 +292,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     }
   ],
   "group": "kg-construct",
-  "latestVersion": "https://w3id.org/rml/lv/spec/",
+  "latestVersion": "https://kg-construct.github.io/rml-lv/spec/docs/",
   "issueBase": "https://github.com/kg-construct/rml-lv/issues",
   "noRecTrack": "true",
   "otherLinks": [
@@ -300,8 +300,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "key": "This Version",
       "data": [
         {
-          "value": "https://w3id.org/rml/lv/spec/20250114/",
-          "href": "https://w3id.org/rml/lv/spec/20250114/"
+          "value": "https://kg-construct.github.io/rml-lv/spec/docs/20250114/",
+          "href": "https://kg-construct.github.io/rml-lv/spec/docs/20250114/"
         }
       ]
     },
@@ -309,8 +309,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "key": "Previous Version",
       "data": [
         {
-          "value": "https://w3id.org/rml/lv/spec/20250114/",
-          "href": "https://w3id.org/rml/lv/spec/20250114/"
+          "value": "https://kg-construct.github.io/rml-lv/spec/docs/20250114/",
+          "href": "https://kg-construct.github.io/rml-lv/spec/docs/20250114/"
         }
       ]
     },
@@ -329,28 +329,28 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 }</script>
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/cg-draft"></head>
 <body class="h-entry"><div class="head">
-    
-    <h1 id="title" class="title">RML Logical Views</h1> 
+
+    <h1 id="title" class="title">RML Logical Views</h1>
     <p id="w3c-state">
       <a href="https://www.w3.org/standards/types#reports">Draft Community Group Report</a>
       <time class="dt-published" datetime="2025-01-14">14 January 2025</time>
     </p>
     <dl>
-      
+
       <dt>Latest published version:</dt><dd>
-              <a href="https://w3id.org/rml/lv/spec/">https://w3id.org/rml/lv/spec/</a>
+              <a href="https://kg-construct.github.io/rml-lv/spec/docs/">https://kg-construct.github.io/rml-lv/spec/docs/</a>
             </dd>
       <dt>Latest editor's draft:</dt><dd><a href="https://w3id.org/rml/lv/spec">https://w3id.org/rml/lv/spec</a></dd>
-      
-      
-      
-      
+
+
+
+
       <dt>Editors:</dt><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:pano@skemu.com">Pano Maria</a> (<a class="p-org org h-org" href="https://skemu.com">Skemu</a>)
   </dd><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:els.devleeschauwer@ugent.be">Els de Vleeschauwer</a> (<a class="p-org org h-org" href="https://idlab.technology/">Ghent University – imec – IDLab</a>)
   </dd>
-      
+
       <dt>Authors:</dt><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:pano@skemu.com">Pano Maria</a> (<a class="p-org org h-org" href="https://skemu.com">Skemu</a>)
   </dd><dd class="editor p-author h-card vcard">
@@ -358,28 +358,28 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   </dd><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:dalanti@unibz.it">Davide Lanti</a> (<a class="p-org org h-org" href="https://www.unibz.it/">Free University of Bozen-Bolzano</a>)
   </dd>
-      
+
       <dt>This Version</dt><dd>
-    <a href="https://w3id.org/rml/lv/spec/20250114/">https://w3id.org/rml/lv/spec/20250114/</a>
+    <a href="https://kg-construct.github.io/rml-lv/spec/docs/20250114/">https://kg-construct.github.io/rml-lv/spec/docs/20250114/</a>
   </dd><dt>Previous Version</dt><dd>
-    <a href="https://w3id.org/rml/lv/spec/20250114/">https://w3id.org/rml/lv/spec/20250114/</a>
+    <a href="https://kg-construct.github.io/rml-lv/spec/docs/20250114/">https://kg-construct.github.io/rml-lv/spec/docs/20250114/</a>
   </dd><dt>Website</dt><dd>
     <a href="https://github.com/kg-construct/rml-lv/">https://github.com/kg-construct/rml-lv/</a>
   </dd>
     </dl>
-    
+
     <p class="copyright">
           <a href="https://www.w3.org/policies/#copyright">Copyright</a>
           ©
           2024-2025
-          
+
           the Contributors to the RML Logical Views
           Specification, published by the
           <a href="https://www.w3.org/groups/cg/kg-construct">Knowledge Graph Construction Community Group</a> under the
           <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>. A human-readable
                 <a href="https://www.w3.org/community/about/agreements/cla-deed/">summary</a>
                 is available.
-              
+
         </p>
     <hr title="Separator for header">
   </div>
@@ -398,11 +398,11 @@ as well as additional information about their fields, through structural annotat
       This specification was published by the
       <a href="https://www.w3.org/groups/cg/kg-construct">Knowledge Graph Construction Community Group</a>. It is not a W3C Standard nor is it
       on the W3C Standards Track.
-      
+
             Please note that under the
             <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>
             there is a limited opt-out and other conditions apply.
-          
+
       Learn more about
       <a href="https://www.w3.org/community/">W3C Community and Business Groups</a>.
     </p>
@@ -413,7 +413,7 @@ yet efforts are made to keep things stable.</p>
 
 <section id="overview-0"><div class="header-wrapper"><h2 id="overview"><bdi class="secno">1. </bdi>Overview</h2><a class="self-link" href="#overview" aria-label="Permalink for Section 1."></a></div><p><em>This section is non-normative.</em></p>
 <section id="document-conventions"><div class="header-wrapper"><h3 id="conventions"><bdi class="secno">1.1 </bdi>Document conventions</h3><a class="self-link" href="#conventions" aria-label="Permalink for Section 1.1"></a></div><p>We assume readers have basic familiarity with RDF and RML concepts.</p>
-<p>In this document, examples assume 
+<p>In this document, examples assume
 the following namespace prefix bindings unless otherwise stated:</p>
 <table>
 <thead>
@@ -463,18 +463,18 @@ the following namespace prefix bindings unless otherwise stated:</p>
 <section id="problem-0"><div class="header-wrapper"><h2 id="problem"><bdi class="secno">2. </bdi>Problem</h2><a class="self-link" href="#problem" aria-label="Permalink for Section 2."></a></div><p><em>This section is non-normative.</em></p>
 <p>RML Logical Views aims to resolve challenges such as handling hierarchy of nested data, more flexible joining (also across data hierarchies), and handling data sources that mix source formats.</p>
 <section id="nested-data-structures"><div class="header-wrapper"><h3 id="x2-1-nested-data-structures"><bdi class="secno">2.1 </bdi>Nested data structures</h3><a class="self-link" href="#nested-data-structures" aria-label="Permalink for Section 2.1"></a></div>
-<p>References to nested data structures, like JSON or XML, may return multiple values. These values can be composite: they may again contain multiple values. 
-<cite><a class="respec-offending-element" title="No matching definition found." id="respec-offender-no-matching-definition-found" href="https://w3id.org/rml/core/spec">RML-Core</a></cite> defines mapping constructs that produce results by combining the results of other mapping constructs in a specific order. 
-For example, a <a href="https://w3id.org/rml/core/spec#dfn-triples-map">triples map</a> combines the results of a <a href="https://w3id.org/rml/core/spec#dfn-subject-map">subject map</a> and a <a href="https://w3id.org/rml/core/spec#dfn-predicate-object-map">predicate-object map</a> in that order. 
-Another example is a <a href="https://w3id.org/rml/core/spec#dfn-template-expression">template expression</a>, 
-which combines character strings and zero or more <a href="https://w3id.org/rml/core/spec#dfn-reference-expression">reference expressions</a> in declared order. 
+<p>References to nested data structures, like JSON or XML, may return multiple values. These values can be composite: they may again contain multiple values.
+<cite><a class="respec-offending-element" title="No matching definition found." id="respec-offender-no-matching-definition-found" href="https://w3id.org/rml/core/spec">RML-Core</a></cite> defines mapping constructs that produce results by combining the results of other mapping constructs in a specific order.
+For example, a <a href="https://w3id.org/rml/core/spec#dfn-triples-map">triples map</a> combines the results of a <a href="https://w3id.org/rml/core/spec#dfn-subject-map">subject map</a> and a <a href="https://w3id.org/rml/core/spec#dfn-predicate-object-map">predicate-object map</a> in that order.
+Another example is a <a href="https://w3id.org/rml/core/spec#dfn-template-expression">template expression</a>,
+which combines character strings and zero or more <a href="https://w3id.org/rml/core/spec#dfn-reference-expression">reference expressions</a> in declared order.
 When mapping constructs produce multiple results, the combining mapping constructs will apply an <a href="https://w3id.org/rml/core/spec#dfn-n-ary-cartesian-product">n-ary Cartesian product</a> over the sets of results, maintaining the order of the mapping constructs. In the case of nested data structures, this may cause the generation of results that do not match the source hierarchy, i.e. do not follow the root-to-leaf paths in the source data, since values are combined irrespective of it.</p>
 <p>Furthermore, there is varying expressiveness in data source expression and query languages, and many languages have limited support for hierarchy traversal. For example, JSONPath has no operator to refer to an ancestor in the document hierarchy.</p>
 <p>This limits the ability of <a href="https://kg-construct.github.io/rml-core/spec/docs/">RML-Core</a> to map nested data.</p>
 <aside class="example" id="ex-nesting-problem"><div class="marker">
     <a class="self-link" href="#ex-nesting-problem">Example<bdi> 1</bdi></a>
   </div>
-It is not possible to declare the construction of below output triples from below data source with RML-Core. 
+It is not possible to declare the construction of below output triples from below data source with RML-Core.
 <aside class="ex-input">
 
 <pre><code class="json hljs" aria-busy="false"><span class="hljs-punctuation">{</span>
@@ -524,20 +524,20 @@ It is not possible to declare the construction of below output triples from belo
 <aside class="example" id="ex-mixed-format-problem"><div class="marker">
     <a class="self-link" href="#ex-mixed-format-problem">Example<bdi> 2</bdi></a>
   </div>
-It is not possible to declare the construction of below output triples from below data source with RML-Core. 
+It is not possible to declare the construction of below output triples from below data source with RML-Core.
 <aside class="ex-input">
 
-<pre><code class="csv hljs" aria-busy="false">name,item  
-alice,"{""type"":""sword"",""weight"": 2500}" 
-alice,"{""type"":""shield"",""weight"": 1500}"  
-bob,"{""type"":""flower"",""weight"": 15 }"  
+<pre><code class="csv hljs" aria-busy="false">name,item
+alice,"{""type"":""sword"",""weight"": 2500}"
+alice,"{""type"":""shield"",""weight"": 1500}"
+bob,"{""type"":""flower"",""weight"": 15 }"
 </code></pre>
 </aside>
 
 <aside class="ex-output">
 
 <pre><code class="turtle hljs" aria-busy="false">:person/alice :hasItem "sword" , "shield" .
-:person/bob :hasItem "flower" . 
+:person/bob :hasItem "flower" .
 </code></pre>
 </aside>
 </aside>
@@ -548,7 +548,7 @@ Moreover, <a href="https://kg-construct.github.io/rml-core/spec/docs/">RML-Core<
 <aside class="example" id="ex-mixed-format-problem"><div class="marker">
     <a class="self-link" href="#ex-mixed-format-problem">Example<bdi> 3</bdi></a>
   </div>
-It is not possible to declare the construction of below output triples from below two data sources with RML-Core. 
+It is not possible to declare the construction of below output triples from below two data sources with RML-Core.
 <aside class="ex-input">
 
 <pre><code class="csv hljs" aria-busy="false">name,id
@@ -569,7 +569,7 @@ bob,flower
 
 <aside class="ex-output">
 
-<pre><code class="turtle hljs" aria-busy="false">:person/123 :hasItem "sword", "shield" . 
+<pre><code class="turtle hljs" aria-busy="false">:person/123 :hasItem "sword", "shield" .
 :person/456 :hasItem "flower" .
 </code></pre>
 </aside>
@@ -941,7 +941,7 @@ Describe how logical iteration relates to records.
 <p>There are two types of fields: an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-1">expression field</a> and an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-1">iterable field</a>.</p>
 <p>An <dfn id="dfn-expression-field" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">expression field</dfn> (<code>rml:ExpressionField</code>) is a type of <a href="https://w3id.org/rml/core/spec#dfn-expression-map">expression map</a>.
 Consequently, an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-2">expression field</a> <em class="rfc2119">MUST</em> have an <a href="https://w3id.org/rml/core/spec#dfn-expressions">expression</a>. </p>
-<p>An <dfn id="dfn-iterable-field" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">iterable field</dfn> (<code>rml:IterableField</code>) is a type of <a href="https://w3id.org/rml/core/spec#dfn-iterable">iterable</a>. 
+<p>An <dfn id="dfn-iterable-field" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">iterable field</dfn> (<code>rml:IterableField</code>) is a type of <a href="https://w3id.org/rml/core/spec#dfn-iterable">iterable</a>.
 Consequently, an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-2">iterable field</a> <em class="rfc2119">MUST</em> have a <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> and a <a href="https://w3id.org/rml/core/spec#dfn-iterator">logical iterator</a>.
 If no reference formulation is declared for a field, the reference formulation of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-1">parent</a> is implied. </p>
 <section id="field-parents"><div class="header-wrapper"><h3 id="fieldparents"><bdi class="secno">5.1 </bdi>Field parents</h3><a class="self-link" href="#fieldparents" aria-label="Permalink for Section 5.1"></a></div><p>A <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-5">field</a> <em class="rfc2119">MUST</em> have a <dfn id="dfn-parent" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">parent</dfn> that is either <a href="https://w3id.org/rml/core/spec##dfn-abstract-logical-source">abstract logical source</a> or another <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-6">field</a>. The parent relation <em class="rfc2119">MUST</em> not contain cycles: it is tree-shaped with a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-4">logical view</a> as its root. The transitive parents of a <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-7">field</a>, i.e., the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-8">field</a>'s parent, the parent of the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-9">field</a>'s parent, etcetera, are fittingly called the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-10">field</a>'s <dfn id="dfn-ancestors" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn" class="respec-offending-element" title="Found definition for &quot;ancestors&quot;, but nothing links to it. This is usually a spec bug!">ancestors</dfn>. </p>
@@ -1045,12 +1045,12 @@ Note that the tabular representation of the <a data-link-type="dfn|abstract-op" 
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item"</span> ;
     <span class="hljs-symbol">rml:iterator</span> <span class="hljs-string">"$.items[*]"</span> ;
     <span class="hljs-symbol">rml:field</span> [
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"type"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"$.type"</span> ;
     ] ;
     <span class="hljs-symbol">rml:field</span> [
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"weight"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"$.weight"</span> ;
     ] ;
@@ -1075,7 +1075,7 @@ Note some columns in the table below have been shortened for brevity.
 <th>item.type.#</th>
 <th>item.type</th>
 <th>item.weight.#</th>
-<th>item.weight</th> 
+<th>item.weight</th>
 </tr><tr>
 <td>0</td>
 <td>
@@ -1146,9 +1146,9 @@ Note some columns in the table below have been shortened for brevity.
 
 </aside>
 
-</section><section id="field-reference-formulations"><div class="header-wrapper"><h3 id="fieldreferenceformulations"><bdi class="secno">5.4 </bdi>Field reference formulations</h3><a class="self-link" href="#fieldreferenceformulations" aria-label="Permalink for Section 5.4"></a></div><p>For the evaluation of the expression of an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-4">expression field</a> (<code>rml:ExpressionField</code>) on the records of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-4">parent</a>, the parent's <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> is used. 
+</section><section id="field-reference-formulations"><div class="header-wrapper"><h3 id="fieldreferenceformulations"><bdi class="secno">5.4 </bdi>Field reference formulations</h3><a class="self-link" href="#fieldreferenceformulations" aria-label="Permalink for Section 5.4"></a></div><p>For the evaluation of the expression of an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-4">expression field</a> (<code>rml:ExpressionField</code>) on the records of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-4">parent</a>, the parent's <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> is used.
 Consequently, the parent of an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-5">expression field</a> <em class="rfc2119">MUST</em> be an <a href="https://w3id.org/rml/core/spec##dfn-iterable">iterable</a>, i.e. an <a href="https://w3id.org/rml/core/spec##dfn-abstract-logical-source">abstract logical source</a> or <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-4">iterable field</a>.  </p>
-<p>The default <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-5">iterable field</a> (<code>rml:IterableField</code>) is the <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-5">parent</a>. 
+<p>The default <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-5">iterable field</a> (<code>rml:IterableField</code>) is the <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-5">parent</a>.
 If the <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-6">iterable field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-6">parent</a> is an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-6">expression field</a>, a <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> <em class="rfc2119">MUST</em> be declared for the <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-7">iterable field</a>.
 Declaring a new <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a>, i.e. a <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> that is different from the <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-7">parent</a>, is only allowed when the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-8">parent</a> is an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-7">expression field</a>. </p>
 <aside class="example" id="ex-mixed-format-json-csv"><div class="marker">
@@ -1157,8 +1157,8 @@ Declaring a new <a href="https://w3id.org/rml/core/spec##dfn-reference-formulati
 
 <p>In this example a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-7">logical view</a> is defined on a <a href="https://w3id.org/rml/core/spec#dfn-logical-source">logical source</a> with reference formulation <code>rml:JSONPath</code>.
 The <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-28">field</a> with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-4">declared name</a> "items" is evaluated using this <a href="https://w3id.org/rml/core/spec#dfn-reference-formulation">reference formulation</a>.
-The nested <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-29">field</a> with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-5">declared name</a> "item" has a declared <a href="https://w3id.org/rml/core/spec#dfn-reference-formulation">reference formulation</a> <code>rml:CSV</code> and CSV row as implicit iterator. 
-Its records are a sequence of logical iterations defined by its iterator. 
+The nested <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-29">field</a> with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-5">declared name</a> "item" has a declared <a href="https://w3id.org/rml/core/spec#dfn-reference-formulation">reference formulation</a> <code>rml:CSV</code> and CSV row as implicit iterator.
+Its records are a sequence of logical iterations defined by its iterator.
 The nested fields with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-6">declared name</a> "type" and "weight" are evaluated using the reference formulation <code>rml:CSV</code> from their parent field with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-7">declared name</a> "item".</p>
 <pre><code class="json hljs" aria-busy="false"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"people"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
@@ -1171,7 +1171,7 @@ The nested fields with <a data-link-type="dfn|abstract-op" href="#dfn-declared-n
       <span class="hljs-attr">"items"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"type,weight\nflower,15"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">]</span>
-<span class="hljs-punctuation">}</span>  
+<span class="hljs-punctuation">}</span>
 </code></pre>
 </aside>
 <aside class="ex-mapping">
@@ -1183,24 +1183,24 @@ The nested fields with <a data-link-type="dfn|abstract-op" href="#dfn-declared-n
 
 <span class="hljs-symbol">:mixedJSONView</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalView</span> ;
   <span class="hljs-symbol">rml:viewOn</span> <span class="hljs-symbol">:mixedJSONSource</span> ;
-  <span class="hljs-symbol">rml:field</span> [ 
+  <span class="hljs-symbol">rml:field</span> [
     <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"items"</span> ;
     <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"$.items"</span> ;
-    <span class="hljs-symbol">rml:field</span> [ 
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:IterableField</span> ; 
+    <span class="hljs-symbol">rml:field</span> [
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:IterableField</span> ;
       <span class="hljs-symbol">rml:referenceFormulation</span> <span class="hljs-symbol">rml:CSV;</span>
-      <span class="hljs-symbol">rml:field</span> [ 
-        <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-symbol">rml:field</span> [
+        <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
         <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"type"</span> ;
         <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"type"</span> ;
       ] ;
-      <span class="hljs-symbol">rml:field</span> [ 
+      <span class="hljs-symbol">rml:field</span> [
         <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField;</span>
         <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"weight"</span> ;
         <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"weight"</span> ;
       ] ;
-    ] ; 
+    ] ;
   ] .
 </code></pre>
 </aside>
@@ -1274,8 +1274,8 @@ Note some columns in the table below have been shortened for brevity.
 </aside>
 
 </section><section id="using-field-names-in-triples-maps"><div class="header-wrapper"><h3 id="x5-5-using-field-names-in-triples-maps"><bdi class="secno">5.5 </bdi>Using field names in triples maps</h3><a class="self-link" href="#using-field-names-in-triples-maps" aria-label="Permalink for Section 5.5"></a></div>
-<p>A <dfn data-plurals="field references" id="dfn-field-reference" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">field reference</dfn> is a <a href="https://w3id.org/rml/core/spec#dfn-reference-expression">reference expression</a> that references a defined <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-30">field</a>. 
-A <a data-link-type="dfn|abstract-op" href="#dfn-field-reference" class="internalDFN" id="ref-for-dfn-field-reference-1">field reference</a> <em class="rfc2119">MUST</em> be a defined <a data-link-type="dfn|abstract-op" href="#dfn-field-name" class="internalDFN" id="ref-for-dfn-field-name-2">field name</a> of an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-8">expression field</a>, to obtain the records in the <a data-link-type="dfn|abstract-op" href="#dfn-field-record-sequence" class="internalDFN" id="ref-for-dfn-field-record-sequence-5">field record sequence</a>, or a defined <a data-link-type="dfn|abstract-op" href="#dfn-field-name" class="internalDFN" id="ref-for-dfn-field-name-3">field name</a> followed by the string <code>.#</code> of a <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-31">field</a>, to obtain the index key of the position of the current entry in the <a data-link-type="dfn|abstract-op" href="#dfn-field-record-sequence" class="internalDFN" id="ref-for-dfn-field-record-sequence-6">field record sequence</a>. 
+<p>A <dfn data-plurals="field references" id="dfn-field-reference" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">field reference</dfn> is a <a href="https://w3id.org/rml/core/spec#dfn-reference-expression">reference expression</a> that references a defined <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-30">field</a>.
+A <a data-link-type="dfn|abstract-op" href="#dfn-field-reference" class="internalDFN" id="ref-for-dfn-field-reference-1">field reference</a> <em class="rfc2119">MUST</em> be a defined <a data-link-type="dfn|abstract-op" href="#dfn-field-name" class="internalDFN" id="ref-for-dfn-field-name-2">field name</a> of an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-8">expression field</a>, to obtain the records in the <a data-link-type="dfn|abstract-op" href="#dfn-field-record-sequence" class="internalDFN" id="ref-for-dfn-field-record-sequence-5">field record sequence</a>, or a defined <a data-link-type="dfn|abstract-op" href="#dfn-field-name" class="internalDFN" id="ref-for-dfn-field-name-3">field name</a> followed by the string <code>.#</code> of a <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-31">field</a>, to obtain the index key of the position of the current entry in the <a data-link-type="dfn|abstract-op" href="#dfn-field-record-sequence" class="internalDFN" id="ref-for-dfn-field-record-sequence-6">field record sequence</a>.
 A <a data-link-type="dfn|abstract-op" href="#dfn-field-reference" class="internalDFN" id="ref-for-dfn-field-reference-2">field reference</a> is a special type of <a href="https://w3id.org/rml/core/spec#dfn-reference-expression">reference expression</a> for which no reference formulation need be defined.</p>
 <p>A <a data-link-type="dfn|abstract-op" href="#dfn-field-reference" class="internalDFN" id="ref-for-dfn-field-reference-3">field reference</a> can be used in <a href="https://w3id.org/rml/core/spec#dfn-expression-map">expression maps</a> just as any other <a href="https://w3id.org/rml/core/spec#dfn-reference-expression">reference expression</a>.</p>
 <aside class="example" id="ex-field-in-triples-map"><div class="marker">
@@ -1501,15 +1501,15 @@ A <a data-link-type="dfn|abstract-op" href="#dfn-field-reference" class="interna
     <a class="self-link" href="#ex-leftjoin">Example<bdi> 15</bdi></a>
   </div>
 
-<p>In this example a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-10">logical view</a> with fields built with data from the logical source from <a href="#csviterator" data-matched-text="[[[#csviterator]]]" class="box-ref">Example<bdi> 4</bdi></a> is joined with the logical view from <a href="#ex-field-record-sequence" data-matched-text="[[[#ex-field-record-sequence]]]" class="box-ref">Example<bdi> 12</bdi></a>. 
-In case of a left join (as in the example), this results in 4 logical iterations in the logical view. 
+<p>In this example a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-10">logical view</a> with fields built with data from the logical source from <a href="#csviterator" data-matched-text="[[[#csviterator]]]" class="box-ref">Example<bdi> 4</bdi></a> is joined with the logical view from <a href="#ex-field-record-sequence" data-matched-text="[[[#ex-field-record-sequence]]]" class="box-ref">Example<bdi> 12</bdi></a>.
+In case of a left join (as in the example), this results in 4 logical iterations in the logical view.
 If an inner joins would have been used, the logical view would have only 3 logical iterations. </p>
 <aside class="ex-mapping">
 
 <pre><code class="turtle hljs" aria-busy="false"><span class="hljs-symbol">:csvView</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalView</span> ;
   <span class="hljs-symbol">rml:viewOn</span> <span class="hljs-symbol">:csvSource</span> ;
   <span class="hljs-symbol">rml:field</span> [
-    <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+    <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"name"</span> ;
     <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"name"</span> ;
   ] ;
@@ -1523,9 +1523,9 @@ If an inner joins would have been used, the logical view would have only 3 logic
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_type"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"item.type"</span> ;
     ] ;
@@ -1630,7 +1630,7 @@ If an inner joins would have been used, the logical view would have only 3 logic
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
       <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_type"</span> ;
@@ -1729,7 +1729,7 @@ tobias,789
     <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"id"</span> ;
     <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"id"</span> ;
-  ] . 
+  ] .
 
 <span class="hljs-symbol">:csvView</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalView</span> ;
   <span class="hljs-symbol">rml:viewOn</span> <span class="hljs-symbol">:csvSource</span> ;
@@ -1748,7 +1748,7 @@ tobias,789
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
       <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_type"</span> ;
@@ -1759,13 +1759,13 @@ tobias,789
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_weight"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"item.weight"</span> ;
     ] ;
-  ] ; 
+  ] ;
   <span class="hljs-symbol">rml:leftJoin</span> [
     <span class="hljs-symbol">rml:parentLogicalView</span> <span class="hljs-symbol">:additionalCsvView</span> ;
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
       <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"id"</span> ;
@@ -2139,7 +2139,7 @@ Note that every <a data-link-type="dfn|abstract-op" href="#dfn-foreignkey-annota
 
 
 <section id="references" class="appendix"><div class="header-wrapper"><h2 id="a-references"><bdi class="secno">A. </bdi>References</h2><a class="self-link" href="#references" aria-label="Permalink for Appendix A."></a></div><section id="normative-references"><div class="header-wrapper"><h3 id="a-1-normative-references"><bdi class="secno">A.1 </bdi>Normative references</h3><a class="self-link" href="#normative-references" aria-label="Permalink for Appendix A.1"></a></div>
-    
+
     <dl class="bibliography"><dt id="bib-rfc2119">[RFC2119]</dt><dd>
       <a href="https://www.rfc-editor.org/rfc/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a>
     </dd><dt id="bib-rfc8174">[RFC8174]</dt><dd>
@@ -2155,21 +2155,21 @@ Note that every <a data-link-type="dfn|abstract-op" href="#dfn-foreignkey-annota
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-record" aria-label="Permalink for definition: record. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-record-1" title="§ 3. Records">§ 3. Records</a> <a href="#ref-for-dfn-record-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-record-4" title="Reference 4">(4)</a> <a href="#ref-for-dfn-record-5" title="Reference 5">(5)</a> <a href="#ref-for-dfn-record-6" title="Reference 6">(6)</a> <a href="#ref-for-dfn-record-7" title="Reference 7">(7)</a> <a href="#ref-for-dfn-record-8" title="Reference 8">(8)</a> <a href="#ref-for-dfn-record-9" title="Reference 9">(9)</a> <a href="#ref-for-dfn-record-10" title="Reference 10">(10)</a> <a href="#ref-for-dfn-record-11" title="Reference 11">(11)</a> <a href="#ref-for-dfn-record-12" title="Reference 12">(12)</a> <a href="#ref-for-dfn-record-13" title="Reference 13">(13)</a> 
+      <a href="#ref-for-dfn-record-1" title="§ 3. Records">§ 3. Records</a> <a href="#ref-for-dfn-record-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-record-4" title="Reference 4">(4)</a> <a href="#ref-for-dfn-record-5" title="Reference 5">(5)</a> <a href="#ref-for-dfn-record-6" title="Reference 6">(6)</a> <a href="#ref-for-dfn-record-7" title="Reference 7">(7)</a> <a href="#ref-for-dfn-record-8" title="Reference 8">(8)</a> <a href="#ref-for-dfn-record-9" title="Reference 9">(9)</a> <a href="#ref-for-dfn-record-10" title="Reference 10">(10)</a> <a href="#ref-for-dfn-record-11" title="Reference 11">(11)</a> <a href="#ref-for-dfn-record-12" title="Reference 12">(12)</a> <a href="#ref-for-dfn-record-13" title="Reference 13">(13)</a>
     </li><li>
-      <a href="#ref-for-dfn-record-14" title="§ 3.2 Record sequences">§ 3.2 Record sequences</a> 
+      <a href="#ref-for-dfn-record-14" title="§ 3.2 Record sequences">§ 3.2 Record sequences</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-expression-values" aria-label="Links in this document to definition: expression values">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-expression-values" aria-label="Permalink for definition: expression values. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
@@ -2179,21 +2179,21 @@ Note that every <a data-link-type="dfn|abstract-op" href="#dfn-foreignkey-annota
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-record-sequence" aria-label="Permalink for definition: record sequence. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-record-sequence-1" title="§ 3.2 Record sequences">§ 3.2 Record sequences</a> 
+      <a href="#ref-for-dfn-record-sequence-1" title="§ 3.2 Record sequences">§ 3.2 Record sequences</a>
     </li><li>
-      <a href="#ref-for-dfn-record-sequence-2" title="§ 5.3 Field record sequences and records">§ 5.3 Field record sequences and records</a> 
+      <a href="#ref-for-dfn-record-sequence-2" title="§ 5.3 Field record sequences and records">§ 5.3 Field record sequences and records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-iterator-record-sequence" aria-label="Links in this document to definition: iterator record sequence">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-iterator-record-sequence" aria-label="Permalink for definition: iterator record sequence. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
@@ -2203,121 +2203,121 @@ Note that every <a data-link-type="dfn|abstract-op" href="#dfn-foreignkey-annota
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view" aria-label="Permalink for definition: logical view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-1" title="§ 4. Logical views">§ 4. Logical views</a> <a href="#ref-for-dfn-logical-view-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-1" title="§ 4. Logical views">§ 4. Logical views</a> <a href="#ref-for-dfn-logical-view-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-3" title="§ 5. Fields">§ 5. Fields</a> 
+      <a href="#ref-for-dfn-logical-view-3" title="§ 5. Fields">§ 5. Fields</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-4" title="§ 5.1 Field parents">§ 5.1 Field parents</a> 
+      <a href="#ref-for-dfn-logical-view-4" title="§ 5.1 Field parents">§ 5.1 Field parents</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-5" title="§ 5.2 Field names">§ 5.2 Field names</a> 
+      <a href="#ref-for-dfn-logical-view-5" title="§ 5.2 Field names">§ 5.2 Field names</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-6" title="§ 5.3 Field record sequences and records">§ 5.3 Field record sequences and records</a> 
+      <a href="#ref-for-dfn-logical-view-6" title="§ 5.3 Field record sequences and records">§ 5.3 Field record sequences and records</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-7" title="§ 5.4 Field reference formulations">§ 5.4 Field reference formulations</a> 
+      <a href="#ref-for-dfn-logical-view-7" title="§ 5.4 Field reference formulations">§ 5.4 Field reference formulations</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-8" title="§ 6. Logical view joins">§ 6. Logical view joins</a> <a href="#ref-for-dfn-logical-view-9" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-8" title="§ 6. Logical view joins">§ 6. Logical view joins</a> <a href="#ref-for-dfn-logical-view-9" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-10" title="§ 6.2.1 Left join">§ 6.2.1 Left join</a> 
+      <a href="#ref-for-dfn-logical-view-10" title="§ 6.2.1 Left join">§ 6.2.1 Left join</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-11" title="§ 6.2.3 Two left joins">§ 6.2.3 Two left joins</a> 
+      <a href="#ref-for-dfn-logical-view-11" title="§ 6.2.3 Two left joins">§ 6.2.3 Two left joins</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-12" title="§ 7. Structural Annotations">§ 7. Structural Annotations</a> 
+      <a href="#ref-for-dfn-logical-view-12" title="§ 7. Structural Annotations">§ 7. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-13" title="§ 7.3 PrimaryKey">§ 7.3 PrimaryKey</a> 
+      <a href="#ref-for-dfn-logical-view-13" title="§ 7.3 PrimaryKey">§ 7.3 PrimaryKey</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-14" title="§ 7.6 ForeignKey">§ 7.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-logical-view-14" title="§ 7.6 ForeignKey">§ 7.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-15" title="§ 7.7 Inclusion">§ 7.7 Inclusion</a> 
+      <a href="#ref-for-dfn-logical-view-15" title="§ 7.7 Inclusion">§ 7.7 Inclusion</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-field" aria-label="Links in this document to definition: field">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-field" aria-label="Permalink for definition: field. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-field-1" title="§ 4. Logical views">§ 4. Logical views</a> <a href="#ref-for-dfn-field-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-field-1" title="§ 4. Logical views">§ 4. Logical views</a> <a href="#ref-for-dfn-field-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-3" title="§ 5. Fields">§ 5. Fields</a> <a href="#ref-for-dfn-field-4" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-field-3" title="§ 5. Fields">§ 5. Fields</a> <a href="#ref-for-dfn-field-4" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-5" title="§ 5.1 Field parents">§ 5.1 Field parents</a> <a href="#ref-for-dfn-field-6" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-7" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-8" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-9" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-10" title="Reference 6">(6)</a> 
+      <a href="#ref-for-dfn-field-5" title="§ 5.1 Field parents">§ 5.1 Field parents</a> <a href="#ref-for-dfn-field-6" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-7" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-8" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-9" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-10" title="Reference 6">(6)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-11" title="§ 5.2 Field names">§ 5.2 Field names</a> <a href="#ref-for-dfn-field-12" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-13" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-14" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-15" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-16" title="Reference 6">(6)</a> <a href="#ref-for-dfn-field-17" title="Reference 7">(7)</a> <a href="#ref-for-dfn-field-18" title="Reference 8">(8)</a> <a href="#ref-for-dfn-field-19" title="Reference 9">(9)</a> 
+      <a href="#ref-for-dfn-field-11" title="§ 5.2 Field names">§ 5.2 Field names</a> <a href="#ref-for-dfn-field-12" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-13" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-14" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-15" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-16" title="Reference 6">(6)</a> <a href="#ref-for-dfn-field-17" title="Reference 7">(7)</a> <a href="#ref-for-dfn-field-18" title="Reference 8">(8)</a> <a href="#ref-for-dfn-field-19" title="Reference 9">(9)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-20" title="§ 5.3 Field record sequences and records">§ 5.3 Field record sequences and records</a> <a href="#ref-for-dfn-field-21" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-22" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-23" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-24" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-25" title="Reference 6">(6)</a> <a href="#ref-for-dfn-field-26" title="Reference 7">(7)</a> <a href="#ref-for-dfn-field-27" title="Reference 8">(8)</a> 
+      <a href="#ref-for-dfn-field-20" title="§ 5.3 Field record sequences and records">§ 5.3 Field record sequences and records</a> <a href="#ref-for-dfn-field-21" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-22" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-23" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-24" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-25" title="Reference 6">(6)</a> <a href="#ref-for-dfn-field-26" title="Reference 7">(7)</a> <a href="#ref-for-dfn-field-27" title="Reference 8">(8)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-28" title="§ 5.4 Field reference formulations">§ 5.4 Field reference formulations</a> <a href="#ref-for-dfn-field-29" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-field-28" title="§ 5.4 Field reference formulations">§ 5.4 Field reference formulations</a> <a href="#ref-for-dfn-field-29" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-30" title="§ 5.5 Using field names in triples maps">§ 5.5 Using field names in triples maps</a> <a href="#ref-for-dfn-field-31" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-field-30" title="§ 5.5 Using field names in triples maps">§ 5.5 Using field names in triples maps</a> <a href="#ref-for-dfn-field-31" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-expression-field" aria-label="Links in this document to definition: expression field">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-expression-field" aria-label="Permalink for definition: expression field. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-expression-field-1" title="§ 5. Fields">§ 5. Fields</a> <a href="#ref-for-dfn-expression-field-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-expression-field-1" title="§ 5. Fields">§ 5. Fields</a> <a href="#ref-for-dfn-expression-field-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-field-3" title="§ 5.3 Field record sequences and records">§ 5.3 Field record sequences and records</a> 
+      <a href="#ref-for-dfn-expression-field-3" title="§ 5.3 Field record sequences and records">§ 5.3 Field record sequences and records</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-field-4" title="§ 5.4 Field reference formulations">§ 5.4 Field reference formulations</a> <a href="#ref-for-dfn-expression-field-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-expression-field-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-expression-field-7" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-expression-field-4" title="§ 5.4 Field reference formulations">§ 5.4 Field reference formulations</a> <a href="#ref-for-dfn-expression-field-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-expression-field-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-expression-field-7" title="Reference 4">(4)</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-field-8" title="§ 5.5 Using field names in triples maps">§ 5.5 Using field names in triples maps</a> 
+      <a href="#ref-for-dfn-expression-field-8" title="§ 5.5 Using field names in triples maps">§ 5.5 Using field names in triples maps</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-field-9" title="§ 6. Logical view joins">§ 6. Logical view joins</a> 
+      <a href="#ref-for-dfn-expression-field-9" title="§ 6. Logical view joins">§ 6. Logical view joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-iterable-field" aria-label="Links in this document to definition: iterable field">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-iterable-field" aria-label="Permalink for definition: iterable field. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-iterable-field-1" title="§ 5. Fields">§ 5. Fields</a> <a href="#ref-for-dfn-iterable-field-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-iterable-field-1" title="§ 5. Fields">§ 5. Fields</a> <a href="#ref-for-dfn-iterable-field-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-iterable-field-3" title="§ 5.3 Field record sequences and records">§ 5.3 Field record sequences and records</a> 
+      <a href="#ref-for-dfn-iterable-field-3" title="§ 5.3 Field record sequences and records">§ 5.3 Field record sequences and records</a>
     </li><li>
-      <a href="#ref-for-dfn-iterable-field-4" title="§ 5.4 Field reference formulations">§ 5.4 Field reference formulations</a> <a href="#ref-for-dfn-iterable-field-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-field-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-iterable-field-7" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-iterable-field-4" title="§ 5.4 Field reference formulations">§ 5.4 Field reference formulations</a> <a href="#ref-for-dfn-iterable-field-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-field-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-iterable-field-7" title="Reference 4">(4)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-parent" aria-label="Links in this document to definition: parent">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-parent" aria-label="Permalink for definition: parent. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-parent-1" title="§ 5. Fields">§ 5. Fields</a> 
+      <a href="#ref-for-dfn-parent-1" title="§ 5. Fields">§ 5. Fields</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-2" title="§ 5.2 Field names">§ 5.2 Field names</a> 
+      <a href="#ref-for-dfn-parent-2" title="§ 5.2 Field names">§ 5.2 Field names</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-3" title="§ 5.3 Field record sequences and records">§ 5.3 Field record sequences and records</a> 
+      <a href="#ref-for-dfn-parent-3" title="§ 5.3 Field record sequences and records">§ 5.3 Field record sequences and records</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-4" title="§ 5.4 Field reference formulations">§ 5.4 Field reference formulations</a> <a href="#ref-for-dfn-parent-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-parent-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-parent-7" title="Reference 4">(4)</a> <a href="#ref-for-dfn-parent-8" title="Reference 5">(5)</a> 
+      <a href="#ref-for-dfn-parent-4" title="§ 5.4 Field reference formulations">§ 5.4 Field reference formulations</a> <a href="#ref-for-dfn-parent-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-parent-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-parent-7" title="Reference 4">(4)</a> <a href="#ref-for-dfn-parent-8" title="Reference 5">(5)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-ancestors" aria-label="Links in this document to definition: ancestors">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-ancestors" aria-label="Permalink for definition: ancestors. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
@@ -2327,310 +2327,310 @@ Note that every <a data-link-type="dfn|abstract-op" href="#dfn-foreignkey-annota
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-declared-name" aria-label="Permalink for definition: declared name. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-declared-name-1" title="§ 5.2 Field names">§ 5.2 Field names</a> <a href="#ref-for-dfn-declared-name-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-declared-name-1" title="§ 5.2 Field names">§ 5.2 Field names</a> <a href="#ref-for-dfn-declared-name-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-declared-name-3" title="§ 5.3 Field record sequences and records">§ 5.3 Field record sequences and records</a> 
+      <a href="#ref-for-dfn-declared-name-3" title="§ 5.3 Field record sequences and records">§ 5.3 Field record sequences and records</a>
     </li><li>
-      <a href="#ref-for-dfn-declared-name-4" title="§ 5.4 Field reference formulations">§ 5.4 Field reference formulations</a> <a href="#ref-for-dfn-declared-name-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-declared-name-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-declared-name-7" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-declared-name-4" title="§ 5.4 Field reference formulations">§ 5.4 Field reference formulations</a> <a href="#ref-for-dfn-declared-name-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-declared-name-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-declared-name-7" title="Reference 4">(4)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-field-name" aria-label="Links in this document to definition: name">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-field-name" aria-label="Permalink for definition: name. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-field-name-1" title="§ 5. Fields">§ 5. Fields</a> 
+      <a href="#ref-for-dfn-field-name-1" title="§ 5. Fields">§ 5. Fields</a>
     </li><li>
-      <a href="#ref-for-dfn-field-name-2" title="§ 5.5 Using field names in triples maps">§ 5.5 Using field names in triples maps</a> <a href="#ref-for-dfn-field-name-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-field-name-2" title="§ 5.5 Using field names in triples maps">§ 5.5 Using field names in triples maps</a> <a href="#ref-for-dfn-field-name-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-field-record-sequence" aria-label="Links in this document to definition: field record sequence">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-field-record-sequence" aria-label="Permalink for definition: field record sequence. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-field-record-sequence-1" title="§ 5.2 Field names">§ 5.2 Field names</a> 
+      <a href="#ref-for-dfn-field-record-sequence-1" title="§ 5.2 Field names">§ 5.2 Field names</a>
     </li><li>
-      <a href="#ref-for-dfn-field-record-sequence-2" title="§ 5.3 Field record sequences and records">§ 5.3 Field record sequences and records</a> <a href="#ref-for-dfn-field-record-sequence-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-record-sequence-4" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-field-record-sequence-2" title="§ 5.3 Field record sequences and records">§ 5.3 Field record sequences and records</a> <a href="#ref-for-dfn-field-record-sequence-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-record-sequence-4" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-record-sequence-5" title="§ 5.5 Using field names in triples maps">§ 5.5 Using field names in triples maps</a> <a href="#ref-for-dfn-field-record-sequence-6" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-field-record-sequence-5" title="§ 5.5 Using field names in triples maps">§ 5.5 Using field names in triples maps</a> <a href="#ref-for-dfn-field-record-sequence-6" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-parent-records" aria-label="Links in this document to definition: parent records">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-parent-records" aria-label="Permalink for definition: parent records. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-parent-records-1" title="§ 5.3 Field record sequences and records">§ 5.3 Field record sequences and records</a> 
+      <a href="#ref-for-dfn-parent-records-1" title="§ 5.3 Field record sequences and records">§ 5.3 Field record sequences and records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-field-reference" aria-label="Links in this document to definition: field reference">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-field-reference" aria-label="Permalink for definition: field reference. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-field-reference-1" title="§ 5.5 Using field names in triples maps">§ 5.5 Using field names in triples maps</a> <a href="#ref-for-dfn-field-reference-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-reference-3" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-field-reference-1" title="§ 5.5 Using field names in triples maps">§ 5.5 Using field names in triples maps</a> <a href="#ref-for-dfn-field-reference-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-reference-3" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-reference-4" title="§ 6. Logical view joins">§ 6. Logical view joins</a> 
+      <a href="#ref-for-dfn-field-reference-4" title="§ 6. Logical view joins">§ 6. Logical view joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-logical-view-join" aria-label="Links in this document to definition: logical view join">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view-join" aria-label="Permalink for definition: logical view join. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-join-1" title="§ 4. Logical views">§ 4. Logical views</a> 
+      <a href="#ref-for-dfn-logical-view-join-1" title="§ 4. Logical views">§ 4. Logical views</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-join-2" title="§ 6. Logical view joins">§ 6. Logical view joins</a> <a href="#ref-for-dfn-logical-view-join-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-join-4" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-logical-view-join-2" title="§ 6. Logical view joins">§ 6. Logical view joins</a> <a href="#ref-for-dfn-logical-view-join-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-join-4" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-join-5" title="§ 6.1 Join types">§ 6.1 Join types</a> <a href="#ref-for-dfn-logical-view-join-6" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-join-5" title="§ 6.1 Join types">§ 6.1 Join types</a> <a href="#ref-for-dfn-logical-view-join-6" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-join-7" title="§ 6.2.3 Two left joins">§ 6.2.3 Two left joins</a> 
+      <a href="#ref-for-dfn-logical-view-join-7" title="§ 6.2.3 Two left joins">§ 6.2.3 Two left joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-parent-logical-view" aria-label="Links in this document to definition: parent logical view">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-parent-logical-view" aria-label="Permalink for definition: parent logical view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-parent-logical-view-1" title="§ 6. Logical view joins">§ 6. Logical view joins</a> 
+      <a href="#ref-for-dfn-parent-logical-view-1" title="§ 6. Logical view joins">§ 6. Logical view joins</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-logical-view-2" title="§ 6.1 Join types">§ 6.1 Join types</a> 
+      <a href="#ref-for-dfn-parent-logical-view-2" title="§ 6.1 Join types">§ 6.1 Join types</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-logical-view-3" title="§ 6.2.3 Two left joins">§ 6.2.3 Two left joins</a> 
+      <a href="#ref-for-dfn-parent-logical-view-3" title="§ 6.2.3 Two left joins">§ 6.2.3 Two left joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-child-logical-view" aria-label="Links in this document to definition: child logical view">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-child-logical-view" aria-label="Permalink for definition: child logical view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-child-logical-view-1" title="§ 6. Logical view joins">§ 6. Logical view joins</a> 
+      <a href="#ref-for-dfn-child-logical-view-1" title="§ 6. Logical view joins">§ 6. Logical view joins</a>
     </li><li>
-      <a href="#ref-for-dfn-child-logical-view-2" title="§ 6.1 Join types">§ 6.1 Join types</a> <a href="#ref-for-dfn-child-logical-view-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-child-logical-view-2" title="§ 6.1 Join types">§ 6.1 Join types</a> <a href="#ref-for-dfn-child-logical-view-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-join-property" aria-label="Links in this document to definition: join property">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-join-property" aria-label="Permalink for definition: join property. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-join-property-1" title="§ 6. Logical view joins">§ 6. Logical view joins</a> 
+      <a href="#ref-for-dfn-join-property-1" title="§ 6. Logical view joins">§ 6. Logical view joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-left-join" aria-label="Links in this document to definition: left join">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-left-join" aria-label="Permalink for definition: left join. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-left-join-1" title="§ 6.1 Join types">§ 6.1 Join types</a> 
+      <a href="#ref-for-dfn-left-join-1" title="§ 6.1 Join types">§ 6.1 Join types</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-inner-join" aria-label="Links in this document to definition: inner join">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-inner-join" aria-label="Permalink for definition: inner join. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-inner-join-1" title="§ 6.1 Join types">§ 6.1 Join types</a> 
+      <a href="#ref-for-dfn-inner-join-1" title="§ 6.1 Join types">§ 6.1 Join types</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-structural-annotations" aria-label="Links in this document to definition: Structural annotations">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-structural-annotations" aria-label="Permalink for definition: Structural annotations. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-structural-annotations-1" title="§ 7. Structural Annotations">§ 7. Structural Annotations</a> <a href="#ref-for-dfn-structural-annotations-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-structural-annotations-1" title="§ 7. Structural Annotations">§ 7. Structural Annotations</a> <a href="#ref-for-dfn-structural-annotations-2" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-on-fields" aria-label="Links in this document to definition: on fields">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-on-fields" aria-label="Permalink for definition: on fields. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-on-fields-1" title="§ 7. Structural Annotations">§ 7. Structural Annotations</a> 
+      <a href="#ref-for-dfn-on-fields-1" title="§ 7. Structural Annotations">§ 7. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-2" title="§ 7.2 IriSafe">§ 7.2 IriSafe</a> 
+      <a href="#ref-for-dfn-on-fields-2" title="§ 7.2 IriSafe">§ 7.2 IriSafe</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-3" title="§ 7.3 PrimaryKey">§ 7.3 PrimaryKey</a> 
+      <a href="#ref-for-dfn-on-fields-3" title="§ 7.3 PrimaryKey">§ 7.3 PrimaryKey</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-4" title="§ 7.4 Unique">§ 7.4 Unique</a> 
+      <a href="#ref-for-dfn-on-fields-4" title="§ 7.4 Unique">§ 7.4 Unique</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-5" title="§ 7.5 NotNull">§ 7.5 NotNull</a> 
+      <a href="#ref-for-dfn-on-fields-5" title="§ 7.5 NotNull">§ 7.5 NotNull</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-6" title="§ 7.6 ForeignKey">§ 7.6 ForeignKey</a> <a href="#ref-for-dfn-on-fields-7" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-on-fields-6" title="§ 7.6 ForeignKey">§ 7.6 ForeignKey</a> <a href="#ref-for-dfn-on-fields-7" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-8" title="§ 7.7 Inclusion">§ 7.7 Inclusion</a> 
+      <a href="#ref-for-dfn-on-fields-8" title="§ 7.7 Inclusion">§ 7.7 Inclusion</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-irisafe-annotation" aria-label="Links in this document to definition: IriSafe structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-irisafe-annotation" aria-label="Permalink for definition: IriSafe structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-irisafe-annotation-1" title="§ 7. Structural Annotations">§ 7. Structural Annotations</a> 
+      <a href="#ref-for-dfn-irisafe-annotation-1" title="§ 7. Structural Annotations">§ 7. Structural Annotations</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-primarykey-annotation" aria-label="Links in this document to definition: PrimaryKey structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-primarykey-annotation" aria-label="Permalink for definition: PrimaryKey structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-primarykey-annotation-1" title="§ 7. Structural Annotations">§ 7. Structural Annotations</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-1" title="§ 7. Structural Annotations">§ 7. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-primarykey-annotation-2" title="§ 7.3 PrimaryKey">§ 7.3 PrimaryKey</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-2" title="§ 7.3 PrimaryKey">§ 7.3 PrimaryKey</a>
     </li><li>
-      <a href="#ref-for-dfn-primarykey-annotation-3" title="§ 7.4 Unique">§ 7.4 Unique</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-3" title="§ 7.4 Unique">§ 7.4 Unique</a>
     </li><li>
-      <a href="#ref-for-dfn-primarykey-annotation-4" title="§ 7.5 NotNull">§ 7.5 NotNull</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-4" title="§ 7.5 NotNull">§ 7.5 NotNull</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-unique-annotation" aria-label="Links in this document to definition: Unique structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-unique-annotation" aria-label="Permalink for definition: Unique structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-unique-annotation-1" title="§ 7. Structural Annotations">§ 7. Structural Annotations</a> 
+      <a href="#ref-for-dfn-unique-annotation-1" title="§ 7. Structural Annotations">§ 7. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-unique-annotation-2" title="§ 7.4 Unique">§ 7.4 Unique</a> <a href="#ref-for-dfn-unique-annotation-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-unique-annotation-2" title="§ 7.4 Unique">§ 7.4 Unique</a> <a href="#ref-for-dfn-unique-annotation-3" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-unique-annotation-4" title="§ 7.6 ForeignKey">§ 7.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-unique-annotation-4" title="§ 7.6 ForeignKey">§ 7.6 ForeignKey</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-notnull-annotation" aria-label="Links in this document to definition: NotNull structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-notnull-annotation" aria-label="Permalink for definition: NotNull structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-notnull-annotation-1" title="§ 7. Structural Annotations">§ 7. Structural Annotations</a> 
+      <a href="#ref-for-dfn-notnull-annotation-1" title="§ 7. Structural Annotations">§ 7. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-notnull-annotation-2" title="§ 7.5 NotNull">§ 7.5 NotNull</a> <a href="#ref-for-dfn-notnull-annotation-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-notnull-annotation-2" title="§ 7.5 NotNull">§ 7.5 NotNull</a> <a href="#ref-for-dfn-notnull-annotation-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-foreignkey-annotation" aria-label="Links in this document to definition: ForeignKey structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-foreignkey-annotation" aria-label="Permalink for definition: ForeignKey structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-foreignkey-annotation-1" title="§ 7. Structural Annotations">§ 7. Structural Annotations</a> 
+      <a href="#ref-for-dfn-foreignkey-annotation-1" title="§ 7. Structural Annotations">§ 7. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-foreignkey-annotation-2" title="§ 7.6 ForeignKey">§ 7.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-foreignkey-annotation-2" title="§ 7.6 ForeignKey">§ 7.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-foreignkey-annotation-3" title="§ 7.7 Inclusion">§ 7.7 Inclusion</a> <a href="#ref-for-dfn-foreignkey-annotation-4" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-foreignkey-annotation-3" title="§ 7.7 Inclusion">§ 7.7 Inclusion</a> <a href="#ref-for-dfn-foreignkey-annotation-4" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-target-view" aria-label="Links in this document to definition: target view">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-target-view" aria-label="Permalink for definition: target view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-target-view-1" title="§ 7.6 ForeignKey">§ 7.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-target-view-1" title="§ 7.6 ForeignKey">§ 7.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-target-view-2" title="§ 7.7 Inclusion">§ 7.7 Inclusion</a> <a href="#ref-for-dfn-target-view-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-target-view-2" title="§ 7.7 Inclusion">§ 7.7 Inclusion</a> <a href="#ref-for-dfn-target-view-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-target-fields" aria-label="Links in this document to definition: target fields">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-target-fields" aria-label="Permalink for definition: target fields. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-target-fields-1" title="§ 7.6 ForeignKey">§ 7.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-target-fields-1" title="§ 7.6 ForeignKey">§ 7.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-target-fields-2" title="§ 7.7 Inclusion">§ 7.7 Inclusion</a> 
+      <a href="#ref-for-dfn-target-fields-2" title="§ 7.7 Inclusion">§ 7.7 Inclusion</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-inclusion-annotation" aria-label="Links in this document to definition: Inclusion structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-inclusion-annotation" aria-label="Permalink for definition: Inclusion structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-inclusion-annotation-1" title="§ 7. Structural Annotations">§ 7. Structural Annotations</a> 
+      <a href="#ref-for-dfn-inclusion-annotation-1" title="§ 7. Structural Annotations">§ 7. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-inclusion-annotation-2" title="§ 7.7 Inclusion">§ 7.7 Inclusion</a> <a href="#ref-for-dfn-inclusion-annotation-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-inclusion-annotation-2" title="§ 7.7 Inclusion">§ 7.7 Inclusion</a> <a href="#ref-for-dfn-inclusion-annotation-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><script id="respec-dfn-panel">(() => {

--- a/spec/docs/20250218/index.html
+++ b/spec/docs/20250218/index.html
@@ -42,13 +42,13 @@ dfn{cursor:pointer}
 .dfn-panel li{margin-left:1em}
 .dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
 </style>
-    
+
 <title>RML Logical Views</title>
-    
-    
+
+
 <link rel="stylesheet" type="text/css" href="./20250218/resources/css/extras.css">
-    
-    
+
+
 <style type="text/css">
 
         /* Adapted from R2RML */
@@ -133,13 +133,13 @@ dfn{cursor:pointer}
         th {
           font-weight: bold;
         }
-    
+
 </style>
-    
-    
-    
+
+
+
 <script data-goatcounter="https://rml-fields.goatcounter.com/count" async="" src="//gc.zgo.at/count.js"></script>
-    
+
 <noscript>
         &lt;img src="https://rml-fields.goatcounter.com/count?p=/test-noscript"&gt;
     </noscript>
@@ -292,7 +292,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     }
   ],
   "group": "kg-construct",
-  "latestVersion": "https://w3id.org/rml/lv/spec/",
+  "latestVersion": "https://kg-construct.github.io/rml-lv/spec/docs/",
   "issueBase": "https://github.com/kg-construct/rml-lv/issues",
   "noRecTrack": "true",
   "otherLinks": [
@@ -300,8 +300,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "key": "This Version",
       "data": [
         {
-          "value": "https://w3id.org/rml/lv/spec/20250218/",
-          "href": "https://w3id.org/rml/lv/spec/20250218/"
+          "value": "https://kg-construct.github.io/rml-lv/spec/docs/20250218/",
+          "href": "https://kg-construct.github.io/rml-lv/spec/docs/20250218/"
         }
       ]
     },
@@ -309,8 +309,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "key": "Previous Version",
       "data": [
         {
-          "value": "https://w3id.org/rml/lv/spec/20250114/",
-          "href": "https://w3id.org/rml/lv/spec/20250114/"
+          "value": "https://kg-construct.github.io/rml-lv/spec/docs/20250114/",
+          "href": "https://kg-construct.github.io/rml-lv/spec/docs/20250114/"
         }
       ]
     },
@@ -329,28 +329,28 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 }</script>
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/cg-draft"></head>
 <body class="h-entry"><div class="head">
-    
-    <h1 id="title" class="title">RML Logical Views</h1> 
+
+    <h1 id="title" class="title">RML Logical Views</h1>
     <p id="w3c-state">
       <a href="https://www.w3.org/standards/types#reports">Draft Community Group Report</a>
       <time class="dt-published" datetime="2025-02-18">18 February 2025</time>
     </p>
     <dl>
-      
+
       <dt>Latest published version:</dt><dd>
-              <a href="https://w3id.org/rml/lv/spec/">https://w3id.org/rml/lv/spec/</a>
+              <a href="https://kg-construct.github.io/rml-lv/spec/docs/">https://kg-construct.github.io/rml-lv/spec/docs/</a>
             </dd>
       <dt>Latest editor's draft:</dt><dd><a href="https://w3id.org/rml/lv/spec">https://w3id.org/rml/lv/spec</a></dd>
-      
-      
-      
-      
+
+
+
+
       <dt>Editors:</dt><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:pano@skemu.com">Pano Maria</a> (<a class="p-org org h-org" href="https://skemu.com">Skemu</a>)
   </dd><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:els.devleeschauwer@ugent.be">Els de Vleeschauwer</a> (<a class="p-org org h-org" href="https://idlab.technology/">Ghent University – imec – IDLab</a>)
   </dd>
-      
+
       <dt>Authors:</dt><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:pano@skemu.com">Pano Maria</a> (<a class="p-org org h-org" href="https://skemu.com">Skemu</a>)
   </dd><dd class="editor p-author h-card vcard">
@@ -358,28 +358,28 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   </dd><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:dalanti@unibz.it">Davide Lanti</a> (<a class="p-org org h-org" href="https://www.unibz.it/">Free University of Bozen-Bolzano</a>)
   </dd>
-      
+
       <dt>This Version</dt><dd>
-    <a href="https://w3id.org/rml/lv/spec/20250218/">https://w3id.org/rml/lv/spec/20250218/</a>
+    <a href="https://kg-construct.github.io/rml-lv/spec/docs/20250218/">https://kg-construct.github.io/rml-lv/spec/docs/20250218/</a>
   </dd><dt>Previous Version</dt><dd>
-    <a href="https://w3id.org/rml/lv/spec/20250114/">https://w3id.org/rml/lv/spec/20250114/</a>
+    <a href="https://kg-construct.github.io/rml-lv/spec/docs/20250114/">https://kg-construct.github.io/rml-lv/spec/docs/20250114/</a>
   </dd><dt>Website</dt><dd>
     <a href="https://github.com/kg-construct/rml-lv/">https://github.com/kg-construct/rml-lv/</a>
   </dd>
     </dl>
-    
+
     <p class="copyright">
           <a href="https://www.w3.org/policies/#copyright">Copyright</a>
           ©
           2024-2025
-          
+
           the Contributors to the RML Logical Views
           Specification, published by the
           <a href="https://www.w3.org/groups/cg/kg-construct">Knowledge Graph Construction Community Group</a> under the
           <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>. A human-readable
                 <a href="https://www.w3.org/community/about/agreements/cla-deed/">summary</a>
                 is available.
-              
+
         </p>
     <hr title="Separator for header">
   </div>
@@ -398,11 +398,11 @@ as well as additional information about their fields, through structural annotat
       This specification was published by the
       <a href="https://www.w3.org/groups/cg/kg-construct">Knowledge Graph Construction Community Group</a>. It is not a W3C Standard nor is it
       on the W3C Standards Track.
-      
+
             Please note that under the
             <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>
             there is a limited opt-out and other conditions apply.
-          
+
       Learn more about
       <a href="https://www.w3.org/community/">W3C Community and Business Groups</a>.
     </p>
@@ -413,7 +413,7 @@ yet efforts are made to keep things stable.</p>
 
 <section id="overview-0"><div class="header-wrapper"><h2 id="overview"><bdi class="secno">1. </bdi>Overview</h2><a class="self-link" href="#overview" aria-label="Permalink for Section 1."></a></div><p><em>This section is non-normative.</em></p>
 <section id="document-conventions"><div class="header-wrapper"><h3 id="conventions"><bdi class="secno">1.1 </bdi>Document conventions</h3><a class="self-link" href="#conventions" aria-label="Permalink for Section 1.1"></a></div><p>We assume readers have basic familiarity with RDF and RML concepts.</p>
-<p>In this document, examples assume 
+<p>In this document, examples assume
 the following namespace prefix bindings unless otherwise stated:</p>
 <table>
 <thead>
@@ -463,18 +463,18 @@ the following namespace prefix bindings unless otherwise stated:</p>
 <section id="problem-0"><div class="header-wrapper"><h2 id="problem"><bdi class="secno">2. </bdi>Problem</h2><a class="self-link" href="#problem" aria-label="Permalink for Section 2."></a></div><p><em>This section is non-normative.</em></p>
 <p>RML Logical Views aims to resolve challenges such as handling hierarchy of nested data, more flexible joining (also across data hierarchies), and handling data sources that mix source formats.</p>
 <section id="nested-data-structures"><div class="header-wrapper"><h3 id="x2-1-nested-data-structures"><bdi class="secno">2.1 </bdi>Nested data structures</h3><a class="self-link" href="#nested-data-structures" aria-label="Permalink for Section 2.1"></a></div>
-<p>References to nested data structures, like JSON or XML, may return multiple values. These values can be composite: they may again contain multiple values. 
-[<cite><a class="bibref" data-link-type="biblio" href="#bib-rml-core" title="RML-Core">RML-Core</a></cite>] defines mapping constructs that produce results by combining the results of other mapping constructs in a specific order. 
-For example, a <a href="https://w3id.org/rml/core/spec#dfn-triples-map">triples map</a> combines the results of a <a href="https://w3id.org/rml/core/spec#dfn-subject-map">subject map</a> and a <a href="https://w3id.org/rml/core/spec#dfn-predicate-object-map">predicate-object map</a> in that order. 
-Another example is a <a href="https://w3id.org/rml/core/spec#dfn-template-expression">template expression</a>, 
-which combines character strings and zero or more <a href="https://w3id.org/rml/core/spec#dfn-reference-expression">reference expressions</a> in declared order. 
+<p>References to nested data structures, like JSON or XML, may return multiple values. These values can be composite: they may again contain multiple values.
+[<cite><a class="bibref" data-link-type="biblio" href="#bib-rml-core" title="RML-Core">RML-Core</a></cite>] defines mapping constructs that produce results by combining the results of other mapping constructs in a specific order.
+For example, a <a href="https://w3id.org/rml/core/spec#dfn-triples-map">triples map</a> combines the results of a <a href="https://w3id.org/rml/core/spec#dfn-subject-map">subject map</a> and a <a href="https://w3id.org/rml/core/spec#dfn-predicate-object-map">predicate-object map</a> in that order.
+Another example is a <a href="https://w3id.org/rml/core/spec#dfn-template-expression">template expression</a>,
+which combines character strings and zero or more <a href="https://w3id.org/rml/core/spec#dfn-reference-expression">reference expressions</a> in declared order.
 When mapping constructs produce multiple results, the combining mapping constructs will apply an <a href="https://w3id.org/rml/core/spec#dfn-n-ary-cartesian-product">n-ary Cartesian product</a> over the sets of results, maintaining the order of the mapping constructs. In the case of nested data structures, this may cause the generation of results that do not match the source hierarchy, i.e. do not follow the root-to-leaf paths in the source data, since values are combined irrespective of it.</p>
 <p>Furthermore, there is varying expressiveness in data source expression and query languages, and many languages have limited support for hierarchy traversal. For example, JSONPath has no operator to refer to an ancestor in the document hierarchy [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9535" title="JSONPath: Query Expressions for JSON">RFC9535</a></cite>].</p>
 <p>This limits the ability of <a href="https://kg-construct.github.io/rml-core/spec/docs/">RML-Core</a> to map nested data.</p>
 <aside class="example" id="ex-nesting-problem"><div class="marker">
     <a class="self-link" href="#ex-nesting-problem">Example<bdi> 1</bdi></a>
   </div>
-It is not possible to declare the construction of below output triples from below data source with RML-Core. 
+It is not possible to declare the construction of below output triples from below data source with RML-Core.
 <aside class="ex-input">
 
 <pre><code class="json hljs" aria-busy="false"><span class="hljs-punctuation">{</span>
@@ -524,20 +524,20 @@ It is not possible to declare the construction of below output triples from belo
 <aside class="example" id="ex-mixed-format-problem"><div class="marker">
     <a class="self-link" href="#ex-mixed-format-problem">Example<bdi> 2</bdi></a>
   </div>
-It is not possible to declare the construction of below output triples from below data source with RML-Core. 
+It is not possible to declare the construction of below output triples from below data source with RML-Core.
 <aside class="ex-input">
 
-<pre><code class="csv hljs" aria-busy="false">name,item  
-alice,"{""type"":""sword"",""weight"": 2500}" 
-alice,"{""type"":""shield"",""weight"": 1500}"  
-bob,"{""type"":""flower"",""weight"": 15 }"  
+<pre><code class="csv hljs" aria-busy="false">name,item
+alice,"{""type"":""sword"",""weight"": 2500}"
+alice,"{""type"":""shield"",""weight"": 1500}"
+bob,"{""type"":""flower"",""weight"": 15 }"
 </code></pre>
 </aside>
 
 <aside class="ex-output">
 
 <pre><code class="turtle hljs" aria-busy="false">:person/alice :hasItem "sword" , "shield" .
-:person/bob :hasItem "flower" . 
+:person/bob :hasItem "flower" .
 </code></pre>
 </aside>
 </aside>
@@ -548,7 +548,7 @@ Moreover, <a href="https://kg-construct.github.io/rml-core/spec/docs/">RML-Core<
 <aside class="example" id="ex-mixed-format-problem"><div class="marker">
     <a class="self-link" href="#ex-mixed-format-problem">Example<bdi> 3</bdi></a>
   </div>
-It is not possible to declare the construction of below output triples from below two data sources with RML-Core. 
+It is not possible to declare the construction of below output triples from below two data sources with RML-Core.
 <aside class="ex-input">
 
 <pre><code class="csv hljs" aria-busy="false">name,id
@@ -569,7 +569,7 @@ bob,flower
 
 <aside class="ex-output">
 
-<pre><code class="turtle hljs" aria-busy="false">:person/123 :hasItem "sword", "shield" . 
+<pre><code class="turtle hljs" aria-busy="false">:person/123 :hasItem "sword", "shield" .
 :person/456 :hasItem "flower" .
 </code></pre>
 </aside>
@@ -614,7 +614,7 @@ bob,flower
 </tbody></table>
 <section id="logical-view-iterator"><div class="header-wrapper"><h3 id="logicalviewiterator"><bdi class="secno">3.1 </bdi>Logical view iterator</h3><a class="self-link" href="#logicalviewiterator" aria-label="Permalink for Section 3.1"></a></div><p>The <a href="https://w3id.org/rml/core/spec##dfn-iterator">logical iterator</a> of a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-3">logical view</a> produces a <dfn id="dfn-logical-view-iteration-sequence" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">logical view iteration sequence</dfn>, i.e. an ordered sequence of sets of key-value pairs, where each key is a string and each value a <a data-link-type="dfn|abstract-op" href="#dfn-record" class="internalDFN" id="ref-for-dfn-record-1">record</a> or a positive integer.
 A <dfn data-plurals="records" id="dfn-record" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">record</dfn> is either a <a href="https://w3id.org/rml/core/spec#dfn-iteration">logical iteration</a> or one element of an <a href="https://w3id.org/rml/core//kg-construct.github.io/rml-core/spec/docs/#https://kg-construct.github.io/rml-core/spec/docs/#dfn-expression-evaluation-result">expression evaluation result</a>.
-A <dfn id="dfn-record-key" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">record key</dfn> has a <a data-link-type="dfn|abstract-op" href="#dfn-record" class="internalDFN" id="ref-for-dfn-record-2">record</a> as value. 
+A <dfn id="dfn-record-key" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">record key</dfn> has a <a data-link-type="dfn|abstract-op" href="#dfn-record" class="internalDFN" id="ref-for-dfn-record-2">record</a> as value.
 An <dfn id="dfn-index-key" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">index key</dfn> has a positive integer as value, indicating the position of the corresponding record in  the sequence of the <a href="https://w3id.org/rml/core/spec#dfn-iteration">logical iteration</a> or in the <a href="https://w3id.org/rml/core//kg-construct.github.io/rml-core/spec/docs/#https://kg-construct.github.io/rml-core/spec/docs/#dfn-expression-evaluation-result">expression evaluation result</a> from which it is derived.
 Each set of key-value pairs represents a <a href="https://w3id.org/rml/core/spec#dfn-iteration">logical iteration</a> of the <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-4">logical view</a> , called a <dfn id="dfn-logical-view-iteration" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">logical view iteration</dfn>.
 A <a data-link-type="dfn|abstract-op" href="#dfn-logical-view-iteration-sequence" class="internalDFN" id="ref-for-dfn-logical-view-iteration-sequence-1">logical view iteration sequence</a> <em class="rfc2119">MUST</em> have a finite set of keys that appear in each <a data-link-type="dfn|abstract-op" href="#dfn-logical-view-iteration" class="internalDFN" id="ref-for-dfn-logical-view-iteration-1">logical view iteration</a>.
@@ -843,13 +843,13 @@ The <a href="https://w3id.org/rml/core/spec##dfn-natural-rdf-datatype">natural R
 <p>There are two types of fields: an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-3">expression field</a> and an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-2">iterable field</a>.</p>
 <p>An <dfn id="dfn-expression-field" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">expression field</dfn> (<code>rml:ExpressionField</code>) is a type of <a href="https://w3id.org/rml/core/spec#dfn-expression-map">expression map</a>.
 Consequently, an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-4">expression field</a> <em class="rfc2119">MUST</em> have an <a href="https://w3id.org/rml/core/spec#dfn-expressions">expression</a>. </p>
-<p>An <dfn id="dfn-iterable-field" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">iterable field</dfn> (<code>rml:IterableField</code>) is a type of <a href="https://w3id.org/rml/core/spec#dfn-iterable">iterable</a>. 
+<p>An <dfn id="dfn-iterable-field" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">iterable field</dfn> (<code>rml:IterableField</code>) is a type of <a href="https://w3id.org/rml/core/spec#dfn-iterable">iterable</a>.
 Consequently, an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-3">iterable field</a> <em class="rfc2119">MUST</em> have a <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> and a <a href="https://w3id.org/rml/core/spec#dfn-iterator">logical iterator</a>.
 If no reference formulation is declared for an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-4">iterable field</a>, the reference formulation of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-1">parent</a> is implied. </p>
 <section id="field-parents"><div class="header-wrapper"><h3 id="fieldparents"><bdi class="secno">4.1 </bdi>Field parents</h3><a class="self-link" href="#fieldparents" aria-label="Permalink for Section 4.1"></a></div><p>A <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-6">field</a> <em class="rfc2119">MUST</em> have a <dfn id="dfn-parent" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">parent</dfn> that is either the <a href="https://w3id.org/rml/core/spec##dfn-abstract-logical-source">abstract logical source</a> of the <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-9">logical view</a> or another <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-7">field</a>. The parent relation <em class="rfc2119">MUST</em> not contain cycles: it is tree-shaped with a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-10">logical view</a> as its root. The transitive parents of a <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-8">field</a>, i.e., the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-9">field</a>'s parent, the parent of the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-10">field</a>'s parent, etcetera, are fittingly called the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-11">field</a>'s <dfn id="dfn-ancestors" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn" class="respec-offending-element" title="Found definition for &quot;ancestors&quot;, but nothing links to it. This is usually a spec bug!">ancestors</dfn>. </p>
-</section><section id="field-names"><div class="header-wrapper"><h3 id="fieldnames"><bdi class="secno">4.2 </bdi>Field names</h3><a class="self-link" href="#fieldnames" aria-label="Permalink for Section 4.2"></a></div><p>A <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-12">field</a> <em class="rfc2119">MUST</em> have a <dfn id="dfn-declared-name" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">declared name</dfn> that is an alphanumerical string. Fields with the same <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-2">parent</a> <em class="rfc2119">MUST</em> have different declared names. 
-We distinguish between the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-13">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-1">declared name</a> and the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-14">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-absolute-name" class="internalDFN" id="ref-for-dfn-absolute-name-1">absolute name</a>. 
-If a <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-15">field</a>'s parent is another <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-16">field</a>, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-17">field</a>'s <dfn id="dfn-absolute-name" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">absolute name</dfn> is the concatenation of the name of the parent <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-18">field</a>, a dot <code>.</code>, and the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-19">field</a>'s declared name. 
+</section><section id="field-names"><div class="header-wrapper"><h3 id="fieldnames"><bdi class="secno">4.2 </bdi>Field names</h3><a class="self-link" href="#fieldnames" aria-label="Permalink for Section 4.2"></a></div><p>A <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-12">field</a> <em class="rfc2119">MUST</em> have a <dfn id="dfn-declared-name" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">declared name</dfn> that is an alphanumerical string. Fields with the same <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-2">parent</a> <em class="rfc2119">MUST</em> have different declared names.
+We distinguish between the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-13">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-1">declared name</a> and the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-14">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-absolute-name" class="internalDFN" id="ref-for-dfn-absolute-name-1">absolute name</a>.
+If a <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-15">field</a>'s parent is another <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-16">field</a>, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-17">field</a>'s <dfn id="dfn-absolute-name" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">absolute name</dfn> is the concatenation of the name of the parent <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-18">field</a>, a dot <code>.</code>, and the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-19">field</a>'s declared name.
 Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-20">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-absolute-name" class="internalDFN" id="ref-for-dfn-absolute-name-2">absolute name</a> equals its <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-2">declared name</a>.  </p>
 <aside class="example" id="ex-fieldnames"><div class="marker">
     <a class="self-link" href="#ex-fieldnames">Example<bdi> 5</bdi></a>
@@ -892,7 +892,7 @@ Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="inte
   <span class="hljs-symbol">rml:source</span> <span class="hljs-symbol">:jsonFile</span> ;
   <span class="hljs-symbol">rml:referenceFormulation</span> <span class="hljs-symbol">rml:JSONPath</span> ;
   <span class="hljs-symbol">rml:iterator</span> <span class="hljs-string">"$.people[*]"</span> .
-  
+
 <span class="hljs-symbol">:jsonView</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalView</span> ;
   <span class="hljs-symbol">rml:viewOn</span> <span class="hljs-symbol">:jsonSource</span> ;
   <span class="hljs-symbol">rml:field</span> [
@@ -984,12 +984,12 @@ The underlined keys represent <a data-link-type="dfn|abstract-op" href="#dfn-ref
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item"</span> ;
     <span class="hljs-symbol">rml:iterator</span> <span class="hljs-string">"$.items[*]"</span> ;
     <span class="hljs-symbol">rml:field</span> [
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"type"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"$.type"</span> ;
     ] ;
     <span class="hljs-symbol">rml:field</span> [
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"weight"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"$.weight"</span> ;
     ] ;
@@ -1002,7 +1002,7 @@ The underlined keys represent <a data-link-type="dfn|abstract-op" href="#dfn-ref
 <table>
     <tbody><tr>
         <th><u>#</u></th>
-        <th>&lt;it&gt;</th>   
+        <th>&lt;it&gt;</th>
         <th><u>name.#</u></th>
         <th><u>name</u></th>
         <th><u>item.#</u></th>
@@ -1010,7 +1010,7 @@ The underlined keys represent <a data-link-type="dfn|abstract-op" href="#dfn-ref
         <th><u>item.type.#</u></th>
         <th><u>item.type</u></th>
         <th><u>item.weight.#</u></th>
-        <th><u>item.weight</u></th> 
+        <th><u>item.weight</u></th>
     </tr>
     <tr>
         <td>0</td>
@@ -1033,7 +1033,7 @@ The underlined keys represent <a data-link-type="dfn|abstract-op" href="#dfn-ref
         <td>0</td>
         <td>sword</td>
         <td>0</td>
-        <td>1500</td> 
+        <td>1500</td>
     </tr>
     <tr>
     <td>0</td>
@@ -1087,9 +1087,9 @@ The underlined keys represent <a data-link-type="dfn|abstract-op" href="#dfn-ref
 
 </aside>
 
-</section><section id="field-reference-formulations"><div class="header-wrapper"><h3 id="fieldreferenceformulations"><bdi class="secno">4.4 </bdi>Field reference formulations</h3><a class="self-link" href="#fieldreferenceformulations" aria-label="Permalink for Section 4.4"></a></div><p>For the evaluation of the expression of an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-6">expression field</a> (<code>rml:ExpressionField</code>) on the records of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-4">parent</a>, the parent's <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> is used. 
+</section><section id="field-reference-formulations"><div class="header-wrapper"><h3 id="fieldreferenceformulations"><bdi class="secno">4.4 </bdi>Field reference formulations</h3><a class="self-link" href="#fieldreferenceformulations" aria-label="Permalink for Section 4.4"></a></div><p>For the evaluation of the expression of an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-6">expression field</a> (<code>rml:ExpressionField</code>) on the records of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-4">parent</a>, the parent's <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> is used.
 Consequently, the parent of an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-7">expression field</a> <em class="rfc2119">MUST</em> be an <a href="https://w3id.org/rml/core/spec##dfn-iterable">iterable</a>, i.e. an <a href="https://w3id.org/rml/core/spec##dfn-abstract-logical-source">abstract logical source</a> or <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-6">iterable field</a>.  </p>
-<p>The default <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-7">iterable field</a> (<code>rml:IterableField</code>) is the <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-5">parent</a>. 
+<p>The default <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-7">iterable field</a> (<code>rml:IterableField</code>) is the <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-5">parent</a>.
 If the <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-8">iterable field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-6">parent</a> is an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-8">expression field</a>, a <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> <em class="rfc2119">MUST</em> be declared for the <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-9">iterable field</a>.
 Declaring a new <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a>, i.e. a <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> that is different from the <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-7">parent</a>, is only allowed when the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-8">parent</a> is an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-9">expression field</a>. </p>
 <aside class="example" id="ex-mixed-format-json-csv"><div class="marker">
@@ -1098,8 +1098,8 @@ Declaring a new <a href="https://w3id.org/rml/core/spec##dfn-reference-formulati
 
 <p>In this example a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-13">logical view</a> is defined on a <a href="https://w3id.org/rml/core/spec#dfn-logical-source">logical source</a> with reference formulation <code>rml:JSONPath</code>.
 The <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-30">field</a> with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-6">declared name</a> "items" is evaluated using this <a href="https://w3id.org/rml/core/spec#dfn-reference-formulation">reference formulation</a>.
-The nested <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-31">field</a> with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-7">declared name</a> "item" has a declared <a href="https://w3id.org/rml/core/spec#dfn-reference-formulation">reference formulation</a> <code>rml:CSV</code> and CSV row as implicit iterator. 
-Its records are a sequence of logical iterations defined by its iterator. 
+The nested <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-31">field</a> with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-7">declared name</a> "item" has a declared <a href="https://w3id.org/rml/core/spec#dfn-reference-formulation">reference formulation</a> <code>rml:CSV</code> and CSV row as implicit iterator.
+Its records are a sequence of logical iterations defined by its iterator.
 The nested fields with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-8">declared name</a> "type" and "weight" are evaluated using the reference formulation <code>rml:CSV</code> from their parent field with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-9">declared name</a> "item".</p>
 <pre><code class="json hljs" aria-busy="false"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"people"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
@@ -1112,7 +1112,7 @@ The nested fields with <a data-link-type="dfn|abstract-op" href="#dfn-declared-n
       <span class="hljs-attr">"items"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"type,weight\nflower,15"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">]</span>
-<span class="hljs-punctuation">}</span>  
+<span class="hljs-punctuation">}</span>
 </code></pre>
 </aside>
 <aside class="ex-mapping">
@@ -1124,24 +1124,24 @@ The nested fields with <a data-link-type="dfn|abstract-op" href="#dfn-declared-n
 
 <span class="hljs-symbol">:mixedJSONView</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalView</span> ;
   <span class="hljs-symbol">rml:viewOn</span> <span class="hljs-symbol">:mixedJSONSource</span> ;
-  <span class="hljs-symbol">rml:field</span> [ 
+  <span class="hljs-symbol">rml:field</span> [
     <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"items"</span> ;
     <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"$.items"</span> ;
-    <span class="hljs-symbol">rml:field</span> [ 
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:IterableField</span> ; 
+    <span class="hljs-symbol">rml:field</span> [
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:IterableField</span> ;
       <span class="hljs-symbol">rml:referenceFormulation</span> <span class="hljs-symbol">rml:CSV;</span>
-      <span class="hljs-symbol">rml:field</span> [ 
-        <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-symbol">rml:field</span> [
+        <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
         <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"type"</span> ;
         <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"type"</span> ;
       ] ;
-      <span class="hljs-symbol">rml:field</span> [ 
+      <span class="hljs-symbol">rml:field</span> [
         <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField;</span>
         <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"weight"</span> ;
         <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"weight"</span> ;
       ] ;
-    ] ; 
+    ] ;
   ] .
 </code></pre>
 </aside>
@@ -1255,8 +1255,8 @@ Note some columns in the table below have been shortened for brevity.
     <a class="self-link" href="#ex-leftjoin">Example<bdi> 8</bdi></a>
   </div>
 
-<p>In this example a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-16">logical view</a> with fields built with data from the logical source <code>:csvSource</code> is joined with the logical view from <a href="#ex-field-record-sequence" data-matched-text="[[[#ex-field-record-sequence]]]" class="box-ref">Example<bdi> 6</bdi></a>. 
-In case of a left join (as in the example), this results in 4 logical iterations in the logical view. 
+<p>In this example a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-16">logical view</a> with fields built with data from the logical source <code>:csvSource</code> is joined with the logical view from <a href="#ex-field-record-sequence" data-matched-text="[[[#ex-field-record-sequence]]]" class="box-ref">Example<bdi> 6</bdi></a>.
+In case of a left join (as in the example), this results in 4 logical iterations in the logical view.
 If an inner joins would have been used, the logical view would have only 3 logical iterations. </p>
 <aside class="ex-input">
 
@@ -1272,11 +1272,11 @@ tobias,2005
 <pre><code class="turtle hljs" aria-busy="false"><span class="hljs-symbol">:csvSource</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalSource</span> ;
   <span class="hljs-symbol">rml:source</span> <span class="hljs-symbol">:csvFile</span> ;
   <span class="hljs-symbol">rml:referenceFormulation</span> <span class="hljs-symbol">rml:CSV</span> .
-  
+
 <span class="hljs-symbol">:csvView</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalView</span> ;
   <span class="hljs-symbol">rml:viewOn</span> <span class="hljs-symbol">:csvSource</span> ;
   <span class="hljs-symbol">rml:field</span> [
-    <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+    <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"name"</span> ;
     <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"name"</span> ;
   ] ;
@@ -1290,9 +1290,9 @@ tobias,2005
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_type"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"item.type"</span> ;
     ] ;
@@ -1397,7 +1397,7 @@ tobias,2005
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
       <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_type"</span> ;
@@ -1496,7 +1496,7 @@ tobias,789
     <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"id"</span> ;
     <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"id"</span> ;
-  ] . 
+  ] .
 
 <span class="hljs-symbol">:csvView</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalView</span> ;
   <span class="hljs-symbol">rml:viewOn</span> <span class="hljs-symbol">:csvSource</span> ;
@@ -1515,7 +1515,7 @@ tobias,789
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
       <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_type"</span> ;
@@ -1526,13 +1526,13 @@ tobias,789
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_weight"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"item.weight"</span> ;
     ] ;
-  ] ; 
+  ] ;
   <span class="hljs-symbol">rml:leftJoin</span> [
     <span class="hljs-symbol">rml:parentLogicalView</span> <span class="hljs-symbol">:additionalCsvView</span> ;
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
       <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"id"</span> ;
@@ -1906,7 +1906,7 @@ Note that every <a data-link-type="dfn|abstract-op" href="#dfn-foreignkey-annota
 
 
 <section id="references" class="appendix"><div class="header-wrapper"><h2 id="a-references"><bdi class="secno">A. </bdi>References</h2><a class="self-link" href="#references" aria-label="Permalink for Appendix A."></a></div><section id="normative-references"><div class="header-wrapper"><h3 id="a-1-normative-references"><bdi class="secno">A.1 </bdi>Normative references</h3><a class="self-link" href="#normative-references" aria-label="Permalink for Appendix A.1"></a></div>
-    
+
     <dl class="bibliography"><dt id="bib-rfc2119">[RFC2119]</dt><dd>
       <a href="https://www.rfc-editor.org/rfc/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a>
     </dd><dt id="bib-rfc8174">[RFC8174]</dt><dd>
@@ -1926,231 +1926,231 @@ Note that every <a data-link-type="dfn|abstract-op" href="#dfn-foreignkey-annota
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view" aria-label="Permalink for definition: logical view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-1" title="§ 3. Logical views">§ 3. Logical views</a> <a href="#ref-for-dfn-logical-view-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-1" title="§ 3. Logical views">§ 3. Logical views</a> <a href="#ref-for-dfn-logical-view-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-3" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-4" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-5" title="Reference 3">(3)</a> <a href="#ref-for-dfn-logical-view-6" title="Reference 4">(4)</a> <a href="#ref-for-dfn-logical-view-7" title="Reference 5">(5)</a> 
+      <a href="#ref-for-dfn-logical-view-3" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-4" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-5" title="Reference 3">(3)</a> <a href="#ref-for-dfn-logical-view-6" title="Reference 4">(4)</a> <a href="#ref-for-dfn-logical-view-7" title="Reference 5">(5)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-8" title="§ 4. Fields">§ 4. Fields</a> 
+      <a href="#ref-for-dfn-logical-view-8" title="§ 4. Fields">§ 4. Fields</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-9" title="§ 4.1 Field parents">§ 4.1 Field parents</a> <a href="#ref-for-dfn-logical-view-10" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-9" title="§ 4.1 Field parents">§ 4.1 Field parents</a> <a href="#ref-for-dfn-logical-view-10" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-11" title="§ 4.2 Field names">§ 4.2 Field names</a> 
+      <a href="#ref-for-dfn-logical-view-11" title="§ 4.2 Field names">§ 4.2 Field names</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-12" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-logical-view-12" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-13" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> 
+      <a href="#ref-for-dfn-logical-view-13" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-14" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-logical-view-15" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-14" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-logical-view-15" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-16" title="§ 5.2.1 Left join">§ 5.2.1 Left join</a> 
+      <a href="#ref-for-dfn-logical-view-16" title="§ 5.2.1 Left join">§ 5.2.1 Left join</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-17" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a> 
+      <a href="#ref-for-dfn-logical-view-17" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-18" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-logical-view-18" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-19" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a> 
+      <a href="#ref-for-dfn-logical-view-19" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-20" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-logical-view-20" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-21" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> 
+      <a href="#ref-for-dfn-logical-view-21" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-logical-view-iteration-sequence" aria-label="Links in this document to definition: logical view iteration sequence">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view-iteration-sequence" aria-label="Permalink for definition: logical view iteration sequence. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-iteration-sequence-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-sequence-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-iteration-sequence-2" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-logical-view-iteration-sequence-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-sequence-2" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-logical-view-iteration-sequence-3" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-iteration-sequence-4" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-sequence-4" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-record" aria-label="Links in this document to definition: record">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-record" aria-label="Permalink for definition: record. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-record-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-record-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-record-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> 
+      <a href="#ref-for-dfn-record-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a>
     </li><li>
-      <a href="#ref-for-dfn-record-4" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-record-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-record-7" title="Reference 4">(4)</a> <a href="#ref-for-dfn-record-8" title="Reference 5">(5)</a> 
+      <a href="#ref-for-dfn-record-4" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-record-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-record-7" title="Reference 4">(4)</a> <a href="#ref-for-dfn-record-8" title="Reference 5">(5)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-record-key" aria-label="Links in this document to definition: record key">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-record-key" aria-label="Permalink for definition: record key. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-record-key-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> 
+      <a href="#ref-for-dfn-record-key-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a>
     </li><li>
-      <a href="#ref-for-dfn-record-key-2" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-record-key-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-key-4" title="Reference 3">(3)</a> <a href="#ref-for-dfn-record-key-5" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-record-key-2" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-record-key-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-key-4" title="Reference 3">(3)</a> <a href="#ref-for-dfn-record-key-5" title="Reference 4">(4)</a>
     </li><li>
-      <a href="#ref-for-dfn-record-key-6" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-record-key-6" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-index-key" aria-label="Links in this document to definition: index key">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-index-key" aria-label="Permalink for definition: index key. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-index-key-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> 
+      <a href="#ref-for-dfn-index-key-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a>
     </li><li>
-      <a href="#ref-for-dfn-index-key-2" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-index-key-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-index-key-2" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-index-key-3" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-index-key-4" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-index-key-4" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-logical-view-iteration" aria-label="Links in this document to definition: logical view iteration">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view-iteration" aria-label="Permalink for definition: logical view iteration. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-iteration-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-iteration-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-iteration-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-logical-view-iteration-4" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-iteration-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-iteration-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-logical-view-iteration-4" title="Reference 4">(4)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-iteration-5" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-5" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-logical-view-reference" aria-label="Links in this document to definition: logical view reference">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view-reference" aria-label="Permalink for definition: logical view reference. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-reference-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-logical-view-reference-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-reference-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-logical-view-reference-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-reference-3" title="§ 5. Logical view joins">§ 5. Logical view joins</a> 
+      <a href="#ref-for-dfn-logical-view-reference-3" title="§ 5. Logical view joins">§ 5. Logical view joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-referenceable-key" aria-label="Links in this document to definition: referenceable key">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-referenceable-key" aria-label="Permalink for definition: referenceable key. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-referenceable-key-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> 
+      <a href="#ref-for-dfn-referenceable-key-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a>
     </li><li>
-      <a href="#ref-for-dfn-referenceable-key-2" title="§ 4.2 Field names">§ 4.2 Field names</a> 
+      <a href="#ref-for-dfn-referenceable-key-2" title="§ 4.2 Field names">§ 4.2 Field names</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-field" aria-label="Links in this document to definition: field">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-field" aria-label="Permalink for definition: field. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-field-1" title="§ 3. Logical views">§ 3. Logical views</a> <a href="#ref-for-dfn-field-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-field-1" title="§ 3. Logical views">§ 3. Logical views</a> <a href="#ref-for-dfn-field-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-3" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> 
+      <a href="#ref-for-dfn-field-3" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a>
     </li><li>
-      <a href="#ref-for-dfn-field-4" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-field-5" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-field-4" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-field-5" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-6" title="§ 4.1 Field parents">§ 4.1 Field parents</a> <a href="#ref-for-dfn-field-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-9" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-10" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-11" title="Reference 6">(6)</a> 
+      <a href="#ref-for-dfn-field-6" title="§ 4.1 Field parents">§ 4.1 Field parents</a> <a href="#ref-for-dfn-field-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-9" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-10" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-11" title="Reference 6">(6)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-12" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-field-13" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-14" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-15" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-16" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-17" title="Reference 6">(6)</a> <a href="#ref-for-dfn-field-18" title="Reference 7">(7)</a> <a href="#ref-for-dfn-field-19" title="Reference 8">(8)</a> <a href="#ref-for-dfn-field-20" title="Reference 9">(9)</a> <a href="#ref-for-dfn-field-21" title="Reference 10">(10)</a> 
+      <a href="#ref-for-dfn-field-12" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-field-13" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-14" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-15" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-16" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-17" title="Reference 6">(6)</a> <a href="#ref-for-dfn-field-18" title="Reference 7">(7)</a> <a href="#ref-for-dfn-field-19" title="Reference 8">(8)</a> <a href="#ref-for-dfn-field-20" title="Reference 9">(9)</a> <a href="#ref-for-dfn-field-21" title="Reference 10">(10)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-22" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-field-23" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-24" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-25" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-26" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-27" title="Reference 6">(6)</a> <a href="#ref-for-dfn-field-28" title="Reference 7">(7)</a> <a href="#ref-for-dfn-field-29" title="Reference 8">(8)</a> 
+      <a href="#ref-for-dfn-field-22" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-field-23" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-24" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-25" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-26" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-27" title="Reference 6">(6)</a> <a href="#ref-for-dfn-field-28" title="Reference 7">(7)</a> <a href="#ref-for-dfn-field-29" title="Reference 8">(8)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-30" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-field-31" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-field-30" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-field-31" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-expression-field" aria-label="Links in this document to definition: expression field">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-expression-field" aria-label="Permalink for definition: expression field. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-expression-field-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-expression-field-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-expression-field-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-expression-field-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-field-3" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-expression-field-4" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-expression-field-3" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-expression-field-4" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-field-5" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-expression-field-5" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-field-6" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-expression-field-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-expression-field-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-expression-field-9" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-expression-field-6" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-expression-field-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-expression-field-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-expression-field-9" title="Reference 4">(4)</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-field-10" title="§ 5. Logical view joins">§ 5. Logical view joins</a> 
+      <a href="#ref-for-dfn-expression-field-10" title="§ 5. Logical view joins">§ 5. Logical view joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-iterable-field" aria-label="Links in this document to definition: iterable field">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-iterable-field" aria-label="Permalink for definition: iterable field. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-iterable-field-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> 
+      <a href="#ref-for-dfn-iterable-field-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a>
     </li><li>
-      <a href="#ref-for-dfn-iterable-field-2" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-iterable-field-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-field-4" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-iterable-field-2" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-iterable-field-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-field-4" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-iterable-field-5" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-iterable-field-5" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-iterable-field-6" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-iterable-field-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-field-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-iterable-field-9" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-iterable-field-6" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-iterable-field-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-field-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-iterable-field-9" title="Reference 4">(4)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-parent" aria-label="Links in this document to definition: parent">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-parent" aria-label="Permalink for definition: parent. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-parent-1" title="§ 4. Fields">§ 4. Fields</a> 
+      <a href="#ref-for-dfn-parent-1" title="§ 4. Fields">§ 4. Fields</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-2" title="§ 4.2 Field names">§ 4.2 Field names</a> 
+      <a href="#ref-for-dfn-parent-2" title="§ 4.2 Field names">§ 4.2 Field names</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-3" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-parent-3" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-4" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-parent-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-parent-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-parent-7" title="Reference 4">(4)</a> <a href="#ref-for-dfn-parent-8" title="Reference 5">(5)</a> 
+      <a href="#ref-for-dfn-parent-4" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-parent-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-parent-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-parent-7" title="Reference 4">(4)</a> <a href="#ref-for-dfn-parent-8" title="Reference 5">(5)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-ancestors" aria-label="Links in this document to definition: ancestors">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-ancestors" aria-label="Permalink for definition: ancestors. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
@@ -2160,278 +2160,278 @@ Note that every <a data-link-type="dfn|abstract-op" href="#dfn-foreignkey-annota
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-declared-name" aria-label="Permalink for definition: declared name. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-declared-name-1" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-declared-name-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-declared-name-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-declared-name-4" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-declared-name-1" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-declared-name-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-declared-name-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-declared-name-4" title="Reference 4">(4)</a>
     </li><li>
-      <a href="#ref-for-dfn-declared-name-5" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-declared-name-5" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-declared-name-6" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-declared-name-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-declared-name-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-declared-name-9" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-declared-name-6" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-declared-name-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-declared-name-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-declared-name-9" title="Reference 4">(4)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-absolute-name" aria-label="Links in this document to definition: absolute name">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-absolute-name" aria-label="Permalink for definition: absolute name. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-absolute-name-1" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-absolute-name-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-absolute-name-1" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-absolute-name-2" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-parent-records" aria-label="Links in this document to definition: parent records">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-parent-records" aria-label="Permalink for definition: parent records. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-parent-records-1" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-parent-records-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-parent-records-1" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-parent-records-2" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-logical-view-join" aria-label="Links in this document to definition: logical view join">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view-join" aria-label="Permalink for definition: logical view join. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-join-1" title="§ 3. Logical views">§ 3. Logical views</a> 
+      <a href="#ref-for-dfn-logical-view-join-1" title="§ 3. Logical views">§ 3. Logical views</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-join-2" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-logical-view-join-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-join-4" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-logical-view-join-2" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-logical-view-join-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-join-4" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-join-5" title="§ 5.1 Join types">§ 5.1 Join types</a> <a href="#ref-for-dfn-logical-view-join-6" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-join-5" title="§ 5.1 Join types">§ 5.1 Join types</a> <a href="#ref-for-dfn-logical-view-join-6" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-join-7" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a> 
+      <a href="#ref-for-dfn-logical-view-join-7" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-parent-logical-view" aria-label="Links in this document to definition: parent logical view">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-parent-logical-view" aria-label="Permalink for definition: parent logical view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-parent-logical-view-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a> 
+      <a href="#ref-for-dfn-parent-logical-view-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-logical-view-2" title="§ 5.1 Join types">§ 5.1 Join types</a> 
+      <a href="#ref-for-dfn-parent-logical-view-2" title="§ 5.1 Join types">§ 5.1 Join types</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-logical-view-3" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a> 
+      <a href="#ref-for-dfn-parent-logical-view-3" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-child-logical-view" aria-label="Links in this document to definition: child logical view">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-child-logical-view" aria-label="Permalink for definition: child logical view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-child-logical-view-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a> 
+      <a href="#ref-for-dfn-child-logical-view-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a>
     </li><li>
-      <a href="#ref-for-dfn-child-logical-view-2" title="§ 5.1 Join types">§ 5.1 Join types</a> <a href="#ref-for-dfn-child-logical-view-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-child-logical-view-2" title="§ 5.1 Join types">§ 5.1 Join types</a> <a href="#ref-for-dfn-child-logical-view-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-join-property" aria-label="Links in this document to definition: join property">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-join-property" aria-label="Permalink for definition: join property. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-join-property-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a> 
+      <a href="#ref-for-dfn-join-property-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-left-join" aria-label="Links in this document to definition: left join">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-left-join" aria-label="Permalink for definition: left join. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-left-join-1" title="§ 5.1 Join types">§ 5.1 Join types</a> 
+      <a href="#ref-for-dfn-left-join-1" title="§ 5.1 Join types">§ 5.1 Join types</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-inner-join" aria-label="Links in this document to definition: inner join">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-inner-join" aria-label="Permalink for definition: inner join. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-inner-join-1" title="§ 5.1 Join types">§ 5.1 Join types</a> 
+      <a href="#ref-for-dfn-inner-join-1" title="§ 5.1 Join types">§ 5.1 Join types</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-structural-annotations" aria-label="Links in this document to definition: Structural annotations">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-structural-annotations" aria-label="Permalink for definition: Structural annotations. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-structural-annotations-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> <a href="#ref-for-dfn-structural-annotations-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-structural-annotations-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> <a href="#ref-for-dfn-structural-annotations-2" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-on-fields" aria-label="Links in this document to definition: on fields">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-on-fields" aria-label="Permalink for definition: on fields. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-on-fields-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-on-fields-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-2" title="§ 6.2 IriSafe">§ 6.2 IriSafe</a> 
+      <a href="#ref-for-dfn-on-fields-2" title="§ 6.2 IriSafe">§ 6.2 IriSafe</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-3" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a> 
+      <a href="#ref-for-dfn-on-fields-3" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-4" title="§ 6.4 Unique">§ 6.4 Unique</a> 
+      <a href="#ref-for-dfn-on-fields-4" title="§ 6.4 Unique">§ 6.4 Unique</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-5" title="§ 6.5 NotNull">§ 6.5 NotNull</a> 
+      <a href="#ref-for-dfn-on-fields-5" title="§ 6.5 NotNull">§ 6.5 NotNull</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-6" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> <a href="#ref-for-dfn-on-fields-7" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-on-fields-6" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> <a href="#ref-for-dfn-on-fields-7" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-8" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> 
+      <a href="#ref-for-dfn-on-fields-8" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-irisafe-annotation" aria-label="Links in this document to definition: IriSafe structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-irisafe-annotation" aria-label="Permalink for definition: IriSafe structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-irisafe-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-irisafe-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-primarykey-annotation" aria-label="Links in this document to definition: PrimaryKey structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-primarykey-annotation" aria-label="Permalink for definition: PrimaryKey structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-primarykey-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-primarykey-annotation-2" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-2" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a>
     </li><li>
-      <a href="#ref-for-dfn-primarykey-annotation-3" title="§ 6.4 Unique">§ 6.4 Unique</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-3" title="§ 6.4 Unique">§ 6.4 Unique</a>
     </li><li>
-      <a href="#ref-for-dfn-primarykey-annotation-4" title="§ 6.5 NotNull">§ 6.5 NotNull</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-4" title="§ 6.5 NotNull">§ 6.5 NotNull</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-unique-annotation" aria-label="Links in this document to definition: Unique structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-unique-annotation" aria-label="Permalink for definition: Unique structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-unique-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-unique-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-unique-annotation-2" title="§ 6.4 Unique">§ 6.4 Unique</a> <a href="#ref-for-dfn-unique-annotation-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-unique-annotation-2" title="§ 6.4 Unique">§ 6.4 Unique</a> <a href="#ref-for-dfn-unique-annotation-3" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-unique-annotation-4" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-unique-annotation-4" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-notnull-annotation" aria-label="Links in this document to definition: NotNull structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-notnull-annotation" aria-label="Permalink for definition: NotNull structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-notnull-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-notnull-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-notnull-annotation-2" title="§ 6.5 NotNull">§ 6.5 NotNull</a> <a href="#ref-for-dfn-notnull-annotation-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-notnull-annotation-2" title="§ 6.5 NotNull">§ 6.5 NotNull</a> <a href="#ref-for-dfn-notnull-annotation-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-foreignkey-annotation" aria-label="Links in this document to definition: ForeignKey structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-foreignkey-annotation" aria-label="Permalink for definition: ForeignKey structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-foreignkey-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-foreignkey-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-foreignkey-annotation-2" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-foreignkey-annotation-2" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-foreignkey-annotation-3" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-foreignkey-annotation-4" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-foreignkey-annotation-3" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-foreignkey-annotation-4" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-target-view" aria-label="Links in this document to definition: target view">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-target-view" aria-label="Permalink for definition: target view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-target-view-1" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-target-view-1" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-target-view-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-target-view-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-target-view-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-target-view-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-target-fields" aria-label="Links in this document to definition: target fields">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-target-fields" aria-label="Permalink for definition: target fields. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-target-fields-1" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-target-fields-1" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-target-fields-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> 
+      <a href="#ref-for-dfn-target-fields-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-inclusion-annotation" aria-label="Links in this document to definition: Inclusion structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-inclusion-annotation" aria-label="Permalink for definition: Inclusion structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-inclusion-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-inclusion-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-inclusion-annotation-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-inclusion-annotation-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-inclusion-annotation-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-inclusion-annotation-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><script id="respec-dfn-panel">(() => {

--- a/spec/docs/20250328/index.html
+++ b/spec/docs/20250328/index.html
@@ -42,13 +42,13 @@ dfn{cursor:pointer}
 .dfn-panel li{margin-left:1em}
 .dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
 </style>
-    
+
 <title>RML Logical Views</title>
-    
-    
+
+
 <link rel="stylesheet" type="text/css" href="./20250328/resources/css/extras.css">
-    
-    
+
+
 <style type="text/css">
 
         /* Adapted from R2RML */
@@ -133,13 +133,13 @@ dfn{cursor:pointer}
         th {
           font-weight: bold;
         }
-    
+
 </style>
-    
-    
-    
+
+
+
 <script data-goatcounter="https://rml-fields.goatcounter.com/count" async="" src="//gc.zgo.at/count.js"></script>
-    
+
 <noscript>
         &lt;img src="https://rml-fields.goatcounter.com/count?p=/test-noscript"&gt;
     </noscript>
@@ -291,7 +291,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     }
   ],
   "group": "kg-construct",
-  "latestVersion": "https://w3id.org/rml/lv/spec/",
+  "latestVersion": "https://kg-construct.github.io/rml-lv/spec/docs/",
   "issueBase": "https://github.com/kg-construct/rml-lv/issues",
   "noRecTrack": "true",
   "otherLinks": [
@@ -299,8 +299,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "key": "This Version",
       "data": [
         {
-          "value": "https://w3id.org/rml/lv/spec/20250328/",
-          "href": "https://w3id.org/rml/lv/spec/20250328/"
+          "value": "https://kg-construct.github.io/rml-lv/spec/docs/20250328/",
+          "href": "https://kg-construct.github.io/rml-lv/spec/docs/20250328/"
         }
       ]
     },
@@ -308,8 +308,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "key": "Previous Version",
       "data": [
         {
-          "value": "https://w3id.org/rml/lv/spec/20250218/",
-          "href": "https://w3id.org/rml/lv/spec/20250218/"
+          "value": "https://kg-construct.github.io/rml-lv/spec/docs/20250218/",
+          "href": "https://kg-construct.github.io/rml-lv/spec/docs/20250218/"
         }
       ]
     },
@@ -345,28 +345,28 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 }</script>
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/cg-draft"></head>
 <body class="h-entry"><div class="head">
-    
-    <h1 id="title" class="title">RML Logical Views</h1> 
+
+    <h1 id="title" class="title">RML Logical Views</h1>
     <p id="w3c-state">
       <a href="https://www.w3.org/standards/types#reports">Draft Community Group Report</a>
       <time class="dt-published" datetime="2025-03-28">28 March 2025</time>
     </p>
     <dl>
-      
+
       <dt>Latest published version:</dt><dd>
-              <a href="https://w3id.org/rml/lv/spec/">https://w3id.org/rml/lv/spec/</a>
+              <a href="https://kg-construct.github.io/rml-lv/spec/docs/">https://kg-construct.github.io/rml-lv/spec/docs/</a>
             </dd>
       <dt>Latest editor's draft:</dt><dd><a href="https://w3id.org/rml/lv/spec">https://w3id.org/rml/lv/spec</a></dd>
-      
-      
-      
-      
+
+
+
+
       <dt>Editors:</dt><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:pano@skemu.com">Pano Maria</a> (<a class="p-org org h-org" href="https://skemu.com">Skemu</a>)
   </dd><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:els.devleeschauwer@ugent.be">Els de Vleeschauwer</a> (<a class="p-org org h-org" href="https://idlab.technology/">Ghent University – imec – IDLab</a>)
   </dd>
-      
+
       <dt>Authors:</dt><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:pano@skemu.com">Pano Maria</a> (<a class="p-org org h-org" href="https://skemu.com">Skemu</a>)
   </dd><dd class="editor p-author h-card vcard">
@@ -374,28 +374,28 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   </dd><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:dalanti@unibz.it">Davide Lanti</a> (<a class="p-org org h-org" href="https://www.unibz.it/">Free University of Bozen-Bolzano</a>)
   </dd>
-      
+
       <dt>This Version</dt><dd>
-    <a href="https://w3id.org/rml/lv/spec/20250328/">https://w3id.org/rml/lv/spec/20250328/</a>
+    <a href="https://kg-construct.github.io/rml-lv/spec/docs/20250328/">https://kg-construct.github.io/rml-lv/spec/docs/20250328/</a>
   </dd><dt>Previous Version</dt><dd>
-    <a href="https://w3id.org/rml/lv/spec/20250218/">https://w3id.org/rml/lv/spec/20250218/</a>
+    <a href="https://kg-construct.github.io/rml-lv/spec/docs/20250218/">https://kg-construct.github.io/rml-lv/spec/docs/20250218/</a>
   </dd><dt>Website</dt><dd>
     <a href="https://github.com/kg-construct/rml-lv/">https://github.com/kg-construct/rml-lv/</a>
   </dd>
     </dl>
-    
+
     <p class="copyright">
           <a href="https://www.w3.org/policies/#copyright">Copyright</a>
           ©
           2024-2025
-          
+
           the Contributors to the RML Logical Views
           Specification, published by the
           <a href="https://www.w3.org/groups/cg/kg-construct">Knowledge Graph Construction Community Group</a> under the
           <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>. A human-readable
                 <a href="https://www.w3.org/community/about/agreements/cla-deed/">summary</a>
                 is available.
-              
+
         </p>
     <hr title="Separator for header">
   </div>
@@ -414,11 +414,11 @@ as well as additional information about their fields, through structural annotat
       This specification was published by the
       <a href="https://www.w3.org/groups/cg/kg-construct">Knowledge Graph Construction Community Group</a>. It is not a W3C Standard nor is it
       on the W3C Standards Track.
-      
+
             Please note that under the
             <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>
             there is a limited opt-out and other conditions apply.
-          
+
       Learn more about
       <a href="https://www.w3.org/community/">W3C Community and Business Groups</a>.
     </p>
@@ -429,7 +429,7 @@ yet efforts are made to keep things stable.</p>
 
 <section id="overview-0"><div class="header-wrapper"><h2 id="overview"><bdi class="secno">1. </bdi>Overview</h2><a class="self-link" href="#overview" aria-label="Permalink for Section 1."></a></div><p><em>This section is non-normative.</em></p>
 <section id="document-conventions"><div class="header-wrapper"><h3 id="conventions"><bdi class="secno">1.1 </bdi>Document conventions</h3><a class="self-link" href="#conventions" aria-label="Permalink for Section 1.1"></a></div><p>We assume readers have basic familiarity with RDF and RML concepts.</p>
-<p>In this document, examples assume 
+<p>In this document, examples assume
 the following namespace prefix bindings unless otherwise stated:</p>
 <table>
 <thead>
@@ -479,18 +479,18 @@ the following namespace prefix bindings unless otherwise stated:</p>
 <section id="problem-0"><div class="header-wrapper"><h2 id="problem"><bdi class="secno">2. </bdi>Problem</h2><a class="self-link" href="#problem" aria-label="Permalink for Section 2."></a></div><p><em>This section is non-normative.</em></p>
 <p>RML Logical Views aims to resolve challenges such as handling hierarchy of nested data, more flexible joining (also across data hierarchies), and handling data sources that mix source formats.</p>
 <section id="nested-data-structures"><div class="header-wrapper"><h3 id="x2-1-nested-data-structures"><bdi class="secno">2.1 </bdi>Nested data structures</h3><a class="self-link" href="#nested-data-structures" aria-label="Permalink for Section 2.1"></a></div>
-<p>References to nested data structures, like JSON or XML, may return multiple values. These values can be composite: they may again contain multiple values. 
-[<cite><a class="bibref" data-link-type="biblio" href="#bib-rml-core" title="RML-Core">RML-Core</a></cite>] defines mapping constructs that produce results by combining the results of other mapping constructs in a specific order. 
-For example, a <a href="https://w3id.org/rml/core/spec#dfn-triples-map">triples map</a> combines the results of a <a href="https://w3id.org/rml/core/spec#dfn-subject-map">subject map</a> and a <a href="https://w3id.org/rml/core/spec#dfn-predicate-object-map">predicate-object map</a> in that order. 
-Another example is a <a href="https://w3id.org/rml/core/spec#dfn-template-expression">template expression</a>, 
-which combines character strings and zero or more <a href="https://w3id.org/rml/core/spec#dfn-reference-expression">reference expressions</a> in declared order. 
+<p>References to nested data structures, like JSON or XML, may return multiple values. These values can be composite: they may again contain multiple values.
+[<cite><a class="bibref" data-link-type="biblio" href="#bib-rml-core" title="RML-Core">RML-Core</a></cite>] defines mapping constructs that produce results by combining the results of other mapping constructs in a specific order.
+For example, a <a href="https://w3id.org/rml/core/spec#dfn-triples-map">triples map</a> combines the results of a <a href="https://w3id.org/rml/core/spec#dfn-subject-map">subject map</a> and a <a href="https://w3id.org/rml/core/spec#dfn-predicate-object-map">predicate-object map</a> in that order.
+Another example is a <a href="https://w3id.org/rml/core/spec#dfn-template-expression">template expression</a>,
+which combines character strings and zero or more <a href="https://w3id.org/rml/core/spec#dfn-reference-expression">reference expressions</a> in declared order.
 When mapping constructs produce multiple results, the combining mapping constructs will apply an <a href="https://w3id.org/rml/core/spec#dfn-n-ary-cartesian-product">n-ary Cartesian product</a> over the sets of results, maintaining the order of the mapping constructs. In the case of nested data structures, this may cause the generation of results that do not match the source hierarchy, i.e. do not follow the root-to-leaf paths in the source data, since values are combined irrespective of it.</p>
 <p>Furthermore, there is varying expressiveness in data source expression and query languages, and many languages have limited support for hierarchy traversal. For example, JSONPath has no operator to refer to an ancestor in the document hierarchy [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9535" title="JSONPath: Query Expressions for JSON">RFC9535</a></cite>].</p>
 <p>This limits the ability of <a href="https://kg-construct.github.io/rml-core/spec/docs/">RML-Core</a> to map nested data.</p>
 <aside class="example" id="ex-nesting-problem"><div class="marker">
     <a class="self-link" href="#ex-nesting-problem">Example<bdi> 1</bdi></a>
   </div>
-It is not possible to declare the construction of below output triples from below data source with RML-Core. 
+It is not possible to declare the construction of below output triples from below data source with RML-Core.
 <aside class="ex-input">
 
 <pre><code class="json hljs" aria-busy="false"><span class="hljs-punctuation">{</span>
@@ -540,20 +540,20 @@ It is not possible to declare the construction of below output triples from belo
 <aside class="example" id="ex-mixed-format-problem"><div class="marker">
     <a class="self-link" href="#ex-mixed-format-problem">Example<bdi> 2</bdi></a>
   </div>
-It is not possible to declare the construction of below output triples from below data source with RML-Core. 
+It is not possible to declare the construction of below output triples from below data source with RML-Core.
 <aside class="ex-input">
 
-<pre><code class="csv hljs" aria-busy="false">name,item  
-alice,"{""type"":""sword"",""weight"": 2500}" 
-alice,"{""type"":""shield"",""weight"": 1500}"  
-bob,"{""type"":""flower"",""weight"": 15 }"  
+<pre><code class="csv hljs" aria-busy="false">name,item
+alice,"{""type"":""sword"",""weight"": 2500}"
+alice,"{""type"":""shield"",""weight"": 1500}"
+bob,"{""type"":""flower"",""weight"": 15 }"
 </code></pre>
 </aside>
 
 <aside class="ex-output">
 
 <pre><code class="turtle hljs" aria-busy="false">:person/alice :hasItem "sword" , "shield" .
-:person/bob :hasItem "flower" . 
+:person/bob :hasItem "flower" .
 </code></pre>
 </aside>
 </aside>
@@ -564,7 +564,7 @@ Moreover, <a href="https://kg-construct.github.io/rml-core/spec/docs/">RML-Core<
 <aside class="example" id="ex-mixed-format-problem"><div class="marker">
     <a class="self-link" href="#ex-mixed-format-problem">Example<bdi> 3</bdi></a>
   </div>
-It is not possible to declare the construction of below output triples from below two data sources with RML-Core. 
+It is not possible to declare the construction of below output triples from below two data sources with RML-Core.
 <aside class="ex-input">
 
 <pre><code class="csv hljs" aria-busy="false">name,id
@@ -585,7 +585,7 @@ bob,flower
 
 <aside class="ex-output">
 
-<pre><code class="turtle hljs" aria-busy="false">:person/123 :hasItem "sword", "shield" . 
+<pre><code class="turtle hljs" aria-busy="false">:person/123 :hasItem "sword", "shield" .
 :person/456 :hasItem "flower" .
 </code></pre>
 </aside>
@@ -634,7 +634,7 @@ Each set of key-value pairs represents a <a href="https://w3id.org/rml/core/spec
 A <dfn data-plurals="records" id="dfn-record" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">record</dfn> is either an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-record" class="internalDFN" id="ref-for-dfn-iterable-record-1">iterable record</a> or an <a data-link-type="dfn|abstract-op" href="#dfn-expression-record" class="internalDFN" id="ref-for-dfn-expression-record-1">expression record</a>.</p>
 <p>An <dfn data-plurals="iterable records" id="dfn-iterable-record" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">iterable record</dfn> is a <a href="https://w3id.org/rml/core/spec#dfn-iteration">logical iteration</a>, i.e. an item on which expressions can be evaluated.</p>
 <p>An <dfn data-plurals="expression records" id="dfn-expression-record" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">expression record</dfn> is one element of an <a href="https://w3id.org/rml/core//kg-construct.github.io/rml-core/spec/docs/#https://kg-construct.github.io/rml-core/spec/docs/#dfn-expression-evaluation-result">expression evaluation result</a>.</p>
-<p>A <dfn data-plurals="record keys" id="dfn-record-key" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">record key</dfn> has a <a data-link-type="dfn|abstract-op" href="#dfn-record" class="internalDFN" id="ref-for-dfn-record-2">record</a> as value. 
+<p>A <dfn data-plurals="record keys" id="dfn-record-key" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">record key</dfn> has a <a data-link-type="dfn|abstract-op" href="#dfn-record" class="internalDFN" id="ref-for-dfn-record-2">record</a> as value.
 Each <a data-link-type="dfn|abstract-op" href="#dfn-record-key" class="internalDFN" id="ref-for-dfn-record-key-1">record key</a> is accompanied with an <a data-link-type="dfn|abstract-op" href="#dfn-index-key" class="internalDFN" id="ref-for-dfn-index-key-1">index key</a>.</p>
 <p>An <dfn id="dfn-index-key" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">index key</dfn> has a non-negative integer as value, indicating the zero-based position of the corresponding record.</p>
 <ul>
@@ -877,13 +877,13 @@ The underlined keys represent <a data-link-type="dfn|abstract-op" href="#dfn-ref
 <p>There are two types of fields: an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-1">expression field</a> and an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-1">iterable field</a>.</p>
 <p>An <dfn id="dfn-expression-field" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">expression field</dfn> (<code>rml:ExpressionField</code>) is a type of <a href="https://w3id.org/rml/core/spec#dfn-expression-map">expression map</a>.
 Consequently, an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-2">expression field</a> <em class="rfc2119">MUST</em> have an <a href="https://w3id.org/rml/core/spec#dfn-expressions">expression</a>. </p>
-<p>An <dfn id="dfn-iterable-field" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">iterable field</dfn> (<code>rml:IterableField</code>) is a type of <a href="https://w3id.org/rml/core/spec#dfn-iterable">iterable</a>. 
+<p>An <dfn id="dfn-iterable-field" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">iterable field</dfn> (<code>rml:IterableField</code>) is a type of <a href="https://w3id.org/rml/core/spec#dfn-iterable">iterable</a>.
 Consequently, an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-2">iterable field</a> <em class="rfc2119">MUST</em> have a <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> and a <a href="https://w3id.org/rml/core/spec#dfn-iterator">logical iterator</a>.
 If no reference formulation is declared for an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-3">iterable field</a>, the reference formulation of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-1">parent</a> is implied. </p>
 <section id="field-parents"><div class="header-wrapper"><h3 id="fieldparents"><bdi class="secno">4.1 </bdi>Field parents</h3><a class="self-link" href="#fieldparents" aria-label="Permalink for Section 4.1"></a></div><p>A <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-6">field</a> <em class="rfc2119">MUST</em> have a <dfn id="dfn-parent" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">parent</dfn> that is either the <a href="https://w3id.org/rml/core/spec##dfn-abstract-logical-source">abstract logical source</a> of the <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-8">logical view</a> or another <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-7">field</a>. The parent relation <em class="rfc2119">MUST</em> not contain cycles: it is tree-shaped with a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-9">logical view</a> as its root. The transitive parents of a <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-8">field</a>, i.e., the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-9">field</a>'s parent, the parent of the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-10">field</a>'s parent, etcetera, are fittingly called the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-11">field</a>'s <dfn id="dfn-ancestors" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn" class="respec-offending-element" title="Found definition for &quot;ancestors&quot;, but nothing links to it. This is usually a spec bug!">ancestors</dfn>. </p>
-</section><section id="field-names"><div class="header-wrapper"><h3 id="fieldnames"><bdi class="secno">4.2 </bdi>Field names</h3><a class="self-link" href="#fieldnames" aria-label="Permalink for Section 4.2"></a></div><p>A <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-12">field</a> <em class="rfc2119">MUST</em> have a <dfn id="dfn-declared-name" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">declared name</dfn> that is an alphanumerical string. Fields with the same <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-2">parent</a> <em class="rfc2119">MUST</em> have different declared names. 
-We distinguish between the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-13">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-2">declared name</a> and the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-14">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-absolute-name" class="internalDFN" id="ref-for-dfn-absolute-name-1">absolute name</a>. 
-If a <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-15">field</a>'s parent is another <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-16">field</a>, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-17">field</a>'s <dfn id="dfn-absolute-name" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">absolute name</dfn> is the concatenation of the name of the parent <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-18">field</a>, a dot <code>.</code>, and the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-19">field</a>'s declared name. 
+</section><section id="field-names"><div class="header-wrapper"><h3 id="fieldnames"><bdi class="secno">4.2 </bdi>Field names</h3><a class="self-link" href="#fieldnames" aria-label="Permalink for Section 4.2"></a></div><p>A <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-12">field</a> <em class="rfc2119">MUST</em> have a <dfn id="dfn-declared-name" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">declared name</dfn> that is an alphanumerical string. Fields with the same <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-2">parent</a> <em class="rfc2119">MUST</em> have different declared names.
+We distinguish between the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-13">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-2">declared name</a> and the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-14">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-absolute-name" class="internalDFN" id="ref-for-dfn-absolute-name-1">absolute name</a>.
+If a <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-15">field</a>'s parent is another <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-16">field</a>, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-17">field</a>'s <dfn id="dfn-absolute-name" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">absolute name</dfn> is the concatenation of the name of the parent <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-18">field</a>, a dot <code>.</code>, and the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-19">field</a>'s declared name.
 Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-20">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-absolute-name" class="internalDFN" id="ref-for-dfn-absolute-name-2">absolute name</a> equals its <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-3">declared name</a>.  </p>
 <aside class="example" id="ex-fieldnames"><div class="marker">
     <a class="self-link" href="#ex-fieldnames">Example<bdi> 5</bdi></a>
@@ -926,7 +926,7 @@ Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="inte
   <span class="hljs-symbol">rml:source</span> <span class="hljs-symbol">:jsonFile</span> ;
   <span class="hljs-symbol">rml:referenceFormulation</span> <span class="hljs-symbol">rml:JSONPath</span> ;
   <span class="hljs-symbol">rml:iterator</span> <span class="hljs-string">"$.people[*]"</span> .
-  
+
 <span class="hljs-symbol">:jsonView</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalView</span> ;
   <span class="hljs-symbol">rml:viewOn</span> <span class="hljs-symbol">:jsonSource</span> ;
   <span class="hljs-symbol">rml:field</span> [
@@ -1018,12 +1018,12 @@ Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="inte
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item"</span> ;
     <span class="hljs-symbol">rml:iterator</span> <span class="hljs-string">"$.items[*]"</span> ;
     <span class="hljs-symbol">rml:field</span> [
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"type"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"$.type"</span> ;
     ] ;
     <span class="hljs-symbol">rml:field</span> [
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"weight"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"$.weight"</span> ;
     ] ;
@@ -1036,7 +1036,7 @@ Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="inte
 <table>
     <tbody><tr>
         <th><u>#</u></th>
-        <th>&lt;it&gt;</th>   
+        <th>&lt;it&gt;</th>
         <th><u>name.#</u></th>
         <th><u>name</u></th>
         <th><u>item.#</u></th>
@@ -1044,7 +1044,7 @@ Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="inte
         <th><u>item.type.#</u></th>
         <th><u>item.type</u></th>
         <th><u>item.weight.#</u></th>
-        <th><u>item.weight</u></th> 
+        <th><u>item.weight</u></th>
     </tr>
     <tr>
         <td>0</td>
@@ -1067,7 +1067,7 @@ Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="inte
         <td>0</td>
         <td>sword</td>
         <td>0</td>
-        <td>1500</td> 
+        <td>1500</td>
     </tr>
     <tr>
     <td>0</td>
@@ -1121,9 +1121,9 @@ Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="inte
 
 </aside>
 
-</section><section id="field-reference-formulations"><div class="header-wrapper"><h3 id="fieldreferenceformulations"><bdi class="secno">4.4 </bdi>Field reference formulations</h3><a class="self-link" href="#fieldreferenceformulations" aria-label="Permalink for Section 4.4"></a></div><p>For the evaluation of the expression of an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-4">expression field</a> (<code>rml:ExpressionField</code>) on the records of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-4">parent</a>, the parent's <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> is used. 
+</section><section id="field-reference-formulations"><div class="header-wrapper"><h3 id="fieldreferenceformulations"><bdi class="secno">4.4 </bdi>Field reference formulations</h3><a class="self-link" href="#fieldreferenceformulations" aria-label="Permalink for Section 4.4"></a></div><p>For the evaluation of the expression of an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-4">expression field</a> (<code>rml:ExpressionField</code>) on the records of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-4">parent</a>, the parent's <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> is used.
 Consequently, the parent of an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-5">expression field</a> <em class="rfc2119">MUST</em> be an <a href="https://w3id.org/rml/core/spec##dfn-iterable">iterable</a>, i.e. an <a href="https://w3id.org/rml/core/spec##dfn-abstract-logical-source">abstract logical source</a> or <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-5">iterable field</a>.  </p>
-<p>The default <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-6">iterable field</a> (<code>rml:IterableField</code>) is the <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-5">parent</a>. 
+<p>The default <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-6">iterable field</a> (<code>rml:IterableField</code>) is the <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-5">parent</a>.
 If the <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-7">iterable field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-6">parent</a> is an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-6">expression field</a>, a <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> <em class="rfc2119">MUST</em> be declared for the <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-8">iterable field</a>.
 Declaring a new <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a>, i.e. a <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> that is different from the <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-7">parent</a>, is only allowed when the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-8">parent</a> is an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-7">expression field</a>. </p>
 <aside class="example" id="ex-mixed-format-json-csv"><div class="marker">
@@ -1132,8 +1132,8 @@ Declaring a new <a href="https://w3id.org/rml/core/spec##dfn-reference-formulati
 
 <p>In this example a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-12">logical view</a> is defined on a <a href="https://w3id.org/rml/core/spec#dfn-logical-source">logical source</a> with reference formulation <code>rml:JSONPath</code>.
 The <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-28">field</a> with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-7">declared name</a> "items" is evaluated using this <a href="https://w3id.org/rml/core/spec#dfn-reference-formulation">reference formulation</a>.
-The nested <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-29">field</a> with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-8">declared name</a> "item" has a declared <a href="https://w3id.org/rml/core/spec#dfn-reference-formulation">reference formulation</a> <code>rml:CSV</code> and CSV row as implicit iterator. 
-Its records are a sequence of logical iterations defined by its iterator. 
+The nested <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-29">field</a> with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-8">declared name</a> "item" has a declared <a href="https://w3id.org/rml/core/spec#dfn-reference-formulation">reference formulation</a> <code>rml:CSV</code> and CSV row as implicit iterator.
+Its records are a sequence of logical iterations defined by its iterator.
 The nested fields with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-9">declared name</a> "type" and "weight" are evaluated using the reference formulation <code>rml:CSV</code> from their parent field with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-10">declared name</a> "item".</p>
 <pre><code class="json hljs" aria-busy="false"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"people"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
@@ -1146,7 +1146,7 @@ The nested fields with <a data-link-type="dfn|abstract-op" href="#dfn-declared-n
       <span class="hljs-attr">"items"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"type,weight\nflower,15"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">]</span>
-<span class="hljs-punctuation">}</span>  
+<span class="hljs-punctuation">}</span>
 </code></pre>
 </aside>
 <aside class="ex-mapping">
@@ -1158,24 +1158,24 @@ The nested fields with <a data-link-type="dfn|abstract-op" href="#dfn-declared-n
 
 <span class="hljs-symbol">:mixedJSONView</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalView</span> ;
   <span class="hljs-symbol">rml:viewOn</span> <span class="hljs-symbol">:mixedJSONSource</span> ;
-  <span class="hljs-symbol">rml:field</span> [ 
+  <span class="hljs-symbol">rml:field</span> [
     <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"items"</span> ;
     <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"$.items"</span> ;
-    <span class="hljs-symbol">rml:field</span> [ 
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:IterableField</span> ; 
+    <span class="hljs-symbol">rml:field</span> [
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:IterableField</span> ;
       <span class="hljs-symbol">rml:referenceFormulation</span> <span class="hljs-symbol">rml:CSV;</span>
-      <span class="hljs-symbol">rml:field</span> [ 
-        <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-symbol">rml:field</span> [
+        <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
         <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"type"</span> ;
         <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"type"</span> ;
       ] ;
-      <span class="hljs-symbol">rml:field</span> [ 
+      <span class="hljs-symbol">rml:field</span> [
         <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField;</span>
         <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"weight"</span> ;
         <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"weight"</span> ;
       ] ;
-    ] ; 
+    ] ;
   ] .
 </code></pre>
 </aside>
@@ -1292,8 +1292,8 @@ The <a data-link-type="dfn|abstract-op" href="#dfn-parent-logical-view" class="i
     <a class="self-link" href="#ex-leftjoin">Example<bdi> 8</bdi></a>
   </div>
 
-<p>In this example a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-15">logical view</a> with fields built with data from the logical source <code>:csvSource</code> is joined with the logical view from <a href="#ex-field-record-sequence" data-matched-text="[[[#ex-field-record-sequence]]]" class="box-ref">Example<bdi> 6</bdi></a>. 
-In case of a left join (as in the example), this results in 4 logical iterations in the logical view. 
+<p>In this example a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-15">logical view</a> with fields built with data from the logical source <code>:csvSource</code> is joined with the logical view from <a href="#ex-field-record-sequence" data-matched-text="[[[#ex-field-record-sequence]]]" class="box-ref">Example<bdi> 6</bdi></a>.
+In case of a left join (as in the example), this results in 4 logical iterations in the logical view.
 If an inner joins would have been used, the logical view would have only 3 logical iterations. </p>
 <aside class="ex-input">
 
@@ -1309,11 +1309,11 @@ tobias,2005
 <pre><code class="turtle hljs" aria-busy="false"><span class="hljs-symbol">:csvSource</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalSource</span> ;
   <span class="hljs-symbol">rml:source</span> <span class="hljs-symbol">:csvFile</span> ;
   <span class="hljs-symbol">rml:referenceFormulation</span> <span class="hljs-symbol">rml:CSV</span> .
-  
+
 <span class="hljs-symbol">:csvView</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalView</span> ;
   <span class="hljs-symbol">rml:viewOn</span> <span class="hljs-symbol">:csvSource</span> ;
   <span class="hljs-symbol">rml:field</span> [
-    <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+    <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"name"</span> ;
     <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"name"</span> ;
   ] ;
@@ -1327,9 +1327,9 @@ tobias,2005
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_type"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"item.type"</span> ;
     ] ;
@@ -1459,7 +1459,7 @@ tobias,2005
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
       <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_type"</span> ;
@@ -1581,7 +1581,7 @@ tobias,789
     <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"id"</span> ;
     <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"id"</span> ;
-  ] . 
+  ] .
 
 <span class="hljs-symbol">:csvView</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalView</span> ;
   <span class="hljs-symbol">rml:viewOn</span> <span class="hljs-symbol">:csvSource</span> ;
@@ -1600,7 +1600,7 @@ tobias,789
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
       <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_type"</span> ;
@@ -1611,13 +1611,13 @@ tobias,789
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_weight"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"item.weight"</span> ;
     ] ;
-  ] ; 
+  ] ;
   <span class="hljs-symbol">rml:leftJoin</span> [
     <span class="hljs-symbol">rml:parentLogicalView</span> <span class="hljs-symbol">:additionalCsvView</span> ;
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
       <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"id"</span> ;
@@ -1679,7 +1679,7 @@ tobias,789
 <pre><code class="json hljs" aria-busy="false">
 {...}
 </code></pre>
-</td>        
+</td>
         <td>0</td>
         <td>shield</td>
         <td>0</td>
@@ -2016,7 +2016,7 @@ Note that every <a data-link-type="dfn|abstract-op" href="#dfn-foreignkey-annota
 
 
 <section id="references" class="appendix"><div class="header-wrapper"><h2 id="a-references"><bdi class="secno">A. </bdi>References</h2><a class="self-link" href="#references" aria-label="Permalink for Appendix A."></a></div><section id="normative-references"><div class="header-wrapper"><h3 id="a-1-normative-references"><bdi class="secno">A.1 </bdi>Normative references</h3><a class="self-link" href="#normative-references" aria-label="Permalink for Appendix A.1"></a></div>
-    
+
     <dl class="bibliography"><dt id="bib-rfc2119">[RFC2119]</dt><dd>
       <a href="https://www.rfc-editor.org/rfc/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a>
     </dd><dt id="bib-rfc8174">[RFC8174]</dt><dd>
@@ -2034,257 +2034,257 @@ Note that every <a data-link-type="dfn|abstract-op" href="#dfn-foreignkey-annota
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view" aria-label="Permalink for definition: logical view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-1" title="§ 3. Logical views">§ 3. Logical views</a> <a href="#ref-for-dfn-logical-view-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-1" title="§ 3. Logical views">§ 3. Logical views</a> <a href="#ref-for-dfn-logical-view-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-3" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-4" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-5" title="Reference 3">(3)</a> <a href="#ref-for-dfn-logical-view-6" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-logical-view-3" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-4" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-5" title="Reference 3">(3)</a> <a href="#ref-for-dfn-logical-view-6" title="Reference 4">(4)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-7" title="§ 4. Fields">§ 4. Fields</a> 
+      <a href="#ref-for-dfn-logical-view-7" title="§ 4. Fields">§ 4. Fields</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-8" title="§ 4.1 Field parents">§ 4.1 Field parents</a> <a href="#ref-for-dfn-logical-view-9" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-8" title="§ 4.1 Field parents">§ 4.1 Field parents</a> <a href="#ref-for-dfn-logical-view-9" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-10" title="§ 4.2 Field names">§ 4.2 Field names</a> 
+      <a href="#ref-for-dfn-logical-view-10" title="§ 4.2 Field names">§ 4.2 Field names</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-11" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-logical-view-11" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-12" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> 
+      <a href="#ref-for-dfn-logical-view-12" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-13" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-logical-view-14" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-13" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-logical-view-14" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-15" title="§ 5.2.1 Left join">§ 5.2.1 Left join</a> 
+      <a href="#ref-for-dfn-logical-view-15" title="§ 5.2.1 Left join">§ 5.2.1 Left join</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-16" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a> 
+      <a href="#ref-for-dfn-logical-view-16" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-17" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-logical-view-17" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-18" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a> 
+      <a href="#ref-for-dfn-logical-view-18" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-19" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-logical-view-19" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-20" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> 
+      <a href="#ref-for-dfn-logical-view-20" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-logical-view-iteration-sequence" aria-label="Links in this document to definition: logical view iteration sequence">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view-iteration-sequence" aria-label="Permalink for definition: logical view iteration sequence. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-iteration-sequence-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-iteration-sequence-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-sequence-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-iteration-sequence-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-iteration-sequence-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-logical-view-iteration-sequence-4" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-sequence-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-logical-view-iteration-sequence-4" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-iteration-sequence-5" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-sequence-5" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-logical-view-iteration" aria-label="Links in this document to definition: logical view iteration">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view-iteration" aria-label="Permalink for definition: logical view iteration. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-iteration-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-iteration-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-iteration-3" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-iteration-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-iteration-3" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-iteration-4" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-4" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-record" aria-label="Links in this document to definition: record">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-record" aria-label="Permalink for definition: record. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-record-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-record-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-record-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> 
+      <a href="#ref-for-dfn-record-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a>
     </li><li>
-      <a href="#ref-for-dfn-record-4" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-record-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-record-7" title="Reference 4">(4)</a> <a href="#ref-for-dfn-record-8" title="Reference 5">(5)</a> 
+      <a href="#ref-for-dfn-record-4" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-record-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-record-7" title="Reference 4">(4)</a> <a href="#ref-for-dfn-record-8" title="Reference 5">(5)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-iterable-record" aria-label="Links in this document to definition: iterable record">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-iterable-record" aria-label="Permalink for definition: iterable record. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-iterable-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-iterable-record-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-record-3" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-iterable-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-iterable-record-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-record-3" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-iterable-record-4" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> 
+      <a href="#ref-for-dfn-iterable-record-4" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a>
     </li><li>
-      <a href="#ref-for-dfn-iterable-record-5" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-iterable-record-5" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-expression-record" aria-label="Links in this document to definition: expression record">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-expression-record" aria-label="Permalink for definition: expression record. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-expression-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-expression-record-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-expression-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-expression-record-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-record-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-expression-record-4" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-expression-record-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-expression-record-4" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-record-5" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-expression-record-5" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-record-key" aria-label="Links in this document to definition: record key">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-record-key" aria-label="Permalink for definition: record key. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-record-key-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-record-key-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-key-3" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-record-key-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-record-key-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-key-3" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-record-key-4" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-record-key-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-key-6" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-record-key-4" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-record-key-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-key-6" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-record-key-7" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-record-key-7" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-index-key" aria-label="Links in this document to definition: index key">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-index-key" aria-label="Permalink for definition: index key. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-index-key-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-index-key-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-index-key-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-index-key-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-index-key-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-index-key-4" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-index-key-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-index-key-4" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-index-key-5" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-index-key-5" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-logical-view-reference" aria-label="Links in this document to definition: logical view reference">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view-reference" aria-label="Permalink for definition: logical view reference. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-reference-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-logical-view-reference-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-reference-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-logical-view-reference-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-reference-3" title="§ 5. Logical view joins">§ 5. Logical view joins</a> 
+      <a href="#ref-for-dfn-logical-view-reference-3" title="§ 5. Logical view joins">§ 5. Logical view joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-referenceable-key" aria-label="Links in this document to definition: referenceable key">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-referenceable-key" aria-label="Permalink for definition: referenceable key. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-referenceable-key-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-referenceable-key-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-referenceable-key-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-referenceable-key-2" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-field" aria-label="Links in this document to definition: field">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-field" aria-label="Permalink for definition: field. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-field-1" title="§ 3. Logical views">§ 3. Logical views</a> <a href="#ref-for-dfn-field-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-field-1" title="§ 3. Logical views">§ 3. Logical views</a> <a href="#ref-for-dfn-field-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-3" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> 
+      <a href="#ref-for-dfn-field-3" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a>
     </li><li>
-      <a href="#ref-for-dfn-field-4" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-field-5" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-field-4" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-field-5" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-6" title="§ 4.1 Field parents">§ 4.1 Field parents</a> <a href="#ref-for-dfn-field-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-9" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-10" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-11" title="Reference 6">(6)</a> 
+      <a href="#ref-for-dfn-field-6" title="§ 4.1 Field parents">§ 4.1 Field parents</a> <a href="#ref-for-dfn-field-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-9" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-10" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-11" title="Reference 6">(6)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-12" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-field-13" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-14" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-15" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-16" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-17" title="Reference 6">(6)</a> <a href="#ref-for-dfn-field-18" title="Reference 7">(7)</a> <a href="#ref-for-dfn-field-19" title="Reference 8">(8)</a> <a href="#ref-for-dfn-field-20" title="Reference 9">(9)</a> <a href="#ref-for-dfn-field-21" title="Reference 10">(10)</a> 
+      <a href="#ref-for-dfn-field-12" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-field-13" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-14" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-15" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-16" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-17" title="Reference 6">(6)</a> <a href="#ref-for-dfn-field-18" title="Reference 7">(7)</a> <a href="#ref-for-dfn-field-19" title="Reference 8">(8)</a> <a href="#ref-for-dfn-field-20" title="Reference 9">(9)</a> <a href="#ref-for-dfn-field-21" title="Reference 10">(10)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-22" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-field-23" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-24" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-25" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-26" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-27" title="Reference 6">(6)</a> 
+      <a href="#ref-for-dfn-field-22" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-field-23" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-24" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-25" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-26" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-27" title="Reference 6">(6)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-28" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-field-29" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-field-28" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-field-29" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-expression-field" aria-label="Links in this document to definition: expression field">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-expression-field" aria-label="Permalink for definition: expression field. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-expression-field-1" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-expression-field-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-expression-field-1" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-expression-field-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-field-3" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-expression-field-3" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-field-4" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-expression-field-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-expression-field-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-expression-field-7" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-expression-field-4" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-expression-field-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-expression-field-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-expression-field-7" title="Reference 4">(4)</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-field-8" title="§ 5. Logical view joins">§ 5. Logical view joins</a> 
+      <a href="#ref-for-dfn-expression-field-8" title="§ 5. Logical view joins">§ 5. Logical view joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-iterable-field" aria-label="Links in this document to definition: iterable field">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-iterable-field" aria-label="Permalink for definition: iterable field. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-iterable-field-1" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-iterable-field-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-field-3" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-iterable-field-1" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-iterable-field-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-field-3" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-iterable-field-4" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-iterable-field-4" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-iterable-field-5" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-iterable-field-6" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-field-7" title="Reference 3">(3)</a> <a href="#ref-for-dfn-iterable-field-8" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-iterable-field-5" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-iterable-field-6" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-field-7" title="Reference 3">(3)</a> <a href="#ref-for-dfn-iterable-field-8" title="Reference 4">(4)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-parent" aria-label="Links in this document to definition: parent">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-parent" aria-label="Permalink for definition: parent. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-parent-1" title="§ 4. Fields">§ 4. Fields</a> 
+      <a href="#ref-for-dfn-parent-1" title="§ 4. Fields">§ 4. Fields</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-2" title="§ 4.2 Field names">§ 4.2 Field names</a> 
+      <a href="#ref-for-dfn-parent-2" title="§ 4.2 Field names">§ 4.2 Field names</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-3" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-parent-3" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-4" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-parent-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-parent-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-parent-7" title="Reference 4">(4)</a> <a href="#ref-for-dfn-parent-8" title="Reference 5">(5)</a> 
+      <a href="#ref-for-dfn-parent-4" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-parent-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-parent-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-parent-7" title="Reference 4">(4)</a> <a href="#ref-for-dfn-parent-8" title="Reference 5">(5)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-ancestors" aria-label="Links in this document to definition: ancestors">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-ancestors" aria-label="Permalink for definition: ancestors. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
@@ -2294,280 +2294,280 @@ Note that every <a data-link-type="dfn|abstract-op" href="#dfn-foreignkey-annota
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-declared-name" aria-label="Permalink for definition: declared name. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-declared-name-1" title="§ 4. Fields">§ 4. Fields</a> 
+      <a href="#ref-for-dfn-declared-name-1" title="§ 4. Fields">§ 4. Fields</a>
     </li><li>
-      <a href="#ref-for-dfn-declared-name-2" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-declared-name-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-declared-name-4" title="Reference 3">(3)</a> <a href="#ref-for-dfn-declared-name-5" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-declared-name-2" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-declared-name-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-declared-name-4" title="Reference 3">(3)</a> <a href="#ref-for-dfn-declared-name-5" title="Reference 4">(4)</a>
     </li><li>
-      <a href="#ref-for-dfn-declared-name-6" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-declared-name-6" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-declared-name-7" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-declared-name-8" title="Reference 2">(2)</a> <a href="#ref-for-dfn-declared-name-9" title="Reference 3">(3)</a> <a href="#ref-for-dfn-declared-name-10" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-declared-name-7" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-declared-name-8" title="Reference 2">(2)</a> <a href="#ref-for-dfn-declared-name-9" title="Reference 3">(3)</a> <a href="#ref-for-dfn-declared-name-10" title="Reference 4">(4)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-absolute-name" aria-label="Links in this document to definition: absolute name">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-absolute-name" aria-label="Permalink for definition: absolute name. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-absolute-name-1" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-absolute-name-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-absolute-name-1" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-absolute-name-2" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-parent-records" aria-label="Links in this document to definition: parent records">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-parent-records" aria-label="Permalink for definition: parent records. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-parent-records-1" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-parent-records-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-parent-records-1" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-parent-records-2" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-logical-view-join" aria-label="Links in this document to definition: logical view join">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view-join" aria-label="Permalink for definition: logical view join. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-join-1" title="§ 3. Logical views">§ 3. Logical views</a> 
+      <a href="#ref-for-dfn-logical-view-join-1" title="§ 3. Logical views">§ 3. Logical views</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-join-2" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-logical-view-join-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-join-4" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-logical-view-join-2" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-logical-view-join-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-join-4" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-join-5" title="§ 5.1 Join types">§ 5.1 Join types</a> <a href="#ref-for-dfn-logical-view-join-6" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-join-5" title="§ 5.1 Join types">§ 5.1 Join types</a> <a href="#ref-for-dfn-logical-view-join-6" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-join-7" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a> 
+      <a href="#ref-for-dfn-logical-view-join-7" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-parent-logical-view" aria-label="Links in this document to definition: parent logical view">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-parent-logical-view" aria-label="Permalink for definition: parent logical view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-parent-logical-view-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-parent-logical-view-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-parent-logical-view-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-parent-logical-view-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-logical-view-3" title="§ 5.1 Join types">§ 5.1 Join types</a> 
+      <a href="#ref-for-dfn-parent-logical-view-3" title="§ 5.1 Join types">§ 5.1 Join types</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-logical-view-4" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a> 
+      <a href="#ref-for-dfn-parent-logical-view-4" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-child-logical-view" aria-label="Links in this document to definition: child logical view">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-child-logical-view" aria-label="Permalink for definition: child logical view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-child-logical-view-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a> 
+      <a href="#ref-for-dfn-child-logical-view-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a>
     </li><li>
-      <a href="#ref-for-dfn-child-logical-view-2" title="§ 5.1 Join types">§ 5.1 Join types</a> <a href="#ref-for-dfn-child-logical-view-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-child-logical-view-2" title="§ 5.1 Join types">§ 5.1 Join types</a> <a href="#ref-for-dfn-child-logical-view-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-join-property" aria-label="Links in this document to definition: join property">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-join-property" aria-label="Permalink for definition: join property. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-join-property-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a> 
+      <a href="#ref-for-dfn-join-property-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-left-join" aria-label="Links in this document to definition: left join">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-left-join" aria-label="Permalink for definition: left join. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-left-join-1" title="§ 5.1 Join types">§ 5.1 Join types</a> 
+      <a href="#ref-for-dfn-left-join-1" title="§ 5.1 Join types">§ 5.1 Join types</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-inner-join" aria-label="Links in this document to definition: inner join">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-inner-join" aria-label="Permalink for definition: inner join. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-inner-join-1" title="§ 5.1 Join types">§ 5.1 Join types</a> 
+      <a href="#ref-for-dfn-inner-join-1" title="§ 5.1 Join types">§ 5.1 Join types</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-structural-annotations" aria-label="Links in this document to definition: Structural annotations">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-structural-annotations" aria-label="Permalink for definition: Structural annotations. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-structural-annotations-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> <a href="#ref-for-dfn-structural-annotations-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-structural-annotations-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> <a href="#ref-for-dfn-structural-annotations-2" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-on-fields" aria-label="Links in this document to definition: on fields">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-on-fields" aria-label="Permalink for definition: on fields. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-on-fields-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-on-fields-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-2" title="§ 6.2 IriSafe">§ 6.2 IriSafe</a> 
+      <a href="#ref-for-dfn-on-fields-2" title="§ 6.2 IriSafe">§ 6.2 IriSafe</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-3" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a> 
+      <a href="#ref-for-dfn-on-fields-3" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-4" title="§ 6.4 Unique">§ 6.4 Unique</a> 
+      <a href="#ref-for-dfn-on-fields-4" title="§ 6.4 Unique">§ 6.4 Unique</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-5" title="§ 6.5 NotNull">§ 6.5 NotNull</a> 
+      <a href="#ref-for-dfn-on-fields-5" title="§ 6.5 NotNull">§ 6.5 NotNull</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-6" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> <a href="#ref-for-dfn-on-fields-7" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-on-fields-6" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> <a href="#ref-for-dfn-on-fields-7" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-8" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> 
+      <a href="#ref-for-dfn-on-fields-8" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-irisafe-annotation" aria-label="Links in this document to definition: IriSafe structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-irisafe-annotation" aria-label="Permalink for definition: IriSafe structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-irisafe-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-irisafe-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-primarykey-annotation" aria-label="Links in this document to definition: PrimaryKey structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-primarykey-annotation" aria-label="Permalink for definition: PrimaryKey structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-primarykey-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-primarykey-annotation-2" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-2" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a>
     </li><li>
-      <a href="#ref-for-dfn-primarykey-annotation-3" title="§ 6.4 Unique">§ 6.4 Unique</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-3" title="§ 6.4 Unique">§ 6.4 Unique</a>
     </li><li>
-      <a href="#ref-for-dfn-primarykey-annotation-4" title="§ 6.5 NotNull">§ 6.5 NotNull</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-4" title="§ 6.5 NotNull">§ 6.5 NotNull</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-unique-annotation" aria-label="Links in this document to definition: Unique structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-unique-annotation" aria-label="Permalink for definition: Unique structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-unique-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-unique-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-unique-annotation-2" title="§ 6.4 Unique">§ 6.4 Unique</a> <a href="#ref-for-dfn-unique-annotation-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-unique-annotation-2" title="§ 6.4 Unique">§ 6.4 Unique</a> <a href="#ref-for-dfn-unique-annotation-3" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-unique-annotation-4" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-unique-annotation-4" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-notnull-annotation" aria-label="Links in this document to definition: NotNull structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-notnull-annotation" aria-label="Permalink for definition: NotNull structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-notnull-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-notnull-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-notnull-annotation-2" title="§ 6.5 NotNull">§ 6.5 NotNull</a> <a href="#ref-for-dfn-notnull-annotation-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-notnull-annotation-2" title="§ 6.5 NotNull">§ 6.5 NotNull</a> <a href="#ref-for-dfn-notnull-annotation-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-foreignkey-annotation" aria-label="Links in this document to definition: ForeignKey structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-foreignkey-annotation" aria-label="Permalink for definition: ForeignKey structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-foreignkey-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-foreignkey-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-foreignkey-annotation-2" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-foreignkey-annotation-2" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-foreignkey-annotation-3" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-foreignkey-annotation-4" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-foreignkey-annotation-3" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-foreignkey-annotation-4" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-target-view" aria-label="Links in this document to definition: target view">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-target-view" aria-label="Permalink for definition: target view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-target-view-1" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-target-view-1" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-target-view-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-target-view-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-target-view-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-target-view-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-target-fields" aria-label="Links in this document to definition: target fields">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-target-fields" aria-label="Permalink for definition: target fields. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-target-fields-1" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-target-fields-1" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-target-fields-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> 
+      <a href="#ref-for-dfn-target-fields-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-inclusion-annotation" aria-label="Links in this document to definition: Inclusion structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-inclusion-annotation" aria-label="Permalink for definition: Inclusion structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-inclusion-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-inclusion-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-inclusion-annotation-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-inclusion-annotation-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-inclusion-annotation-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-inclusion-annotation-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><script id="respec-highlight-vars">(() => {

--- a/spec/docs/index.html
+++ b/spec/docs/index.html
@@ -42,13 +42,13 @@ dfn{cursor:pointer}
 .dfn-panel li{margin-left:1em}
 .dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
 </style>
-    
+
 <title>RML Logical Views</title>
-    
-    
+
+
 <link rel="stylesheet" type="text/css" href="./20250328/resources/css/extras.css">
-    
-    
+
+
 <style type="text/css">
 
         /* Adapted from R2RML */
@@ -133,13 +133,13 @@ dfn{cursor:pointer}
         th {
           font-weight: bold;
         }
-    
+
 </style>
-    
-    
-    
+
+
+
 <script data-goatcounter="https://rml-fields.goatcounter.com/count" async="" src="//gc.zgo.at/count.js"></script>
-    
+
 <noscript>
         &lt;img src="https://rml-fields.goatcounter.com/count?p=/test-noscript"&gt;
     </noscript>
@@ -291,7 +291,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     }
   ],
   "group": "kg-construct",
-  "latestVersion": "https://w3id.org/rml/lv/spec/",
+  "latestVersion": "https://kg-construct.github.io/rml-lv/spec/docs/",
   "issueBase": "https://github.com/kg-construct/rml-lv/issues",
   "noRecTrack": "true",
   "otherLinks": [
@@ -299,8 +299,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "key": "This Version",
       "data": [
         {
-          "value": "https://w3id.org/rml/lv/spec/20250328/",
-          "href": "https://w3id.org/rml/lv/spec/20250328/"
+          "value": "https://kg-construct.github.io/rml-lv/spec/docs/20250328/",
+          "href": "https://kg-construct.github.io/rml-lv/spec/docs/20250328/"
         }
       ]
     },
@@ -308,8 +308,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "key": "Previous Version",
       "data": [
         {
-          "value": "https://w3id.org/rml/lv/spec/20250218/",
-          "href": "https://w3id.org/rml/lv/spec/20250218/"
+          "value": "https://kg-construct.github.io/rml-lv/spec/docs/20250218/",
+          "href": "https://kg-construct.github.io/rml-lv/spec/docs/20250218/"
         }
       ]
     },
@@ -345,28 +345,28 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 }</script>
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/cg-draft"></head>
 <body class="h-entry"><div class="head">
-    
-    <h1 id="title" class="title">RML Logical Views</h1> 
+
+    <h1 id="title" class="title">RML Logical Views</h1>
     <p id="w3c-state">
       <a href="https://www.w3.org/standards/types#reports">Draft Community Group Report</a>
       <time class="dt-published" datetime="2025-03-28">28 March 2025</time>
     </p>
     <dl>
-      
+
       <dt>Latest published version:</dt><dd>
-              <a href="https://w3id.org/rml/lv/spec/">https://w3id.org/rml/lv/spec/</a>
+              <a href="https://kg-construct.github.io/rml-lv/spec/docs/">https://kg-construct.github.io/rml-lv/spec/docs/</a>
             </dd>
       <dt>Latest editor's draft:</dt><dd><a href="https://w3id.org/rml/lv/spec">https://w3id.org/rml/lv/spec</a></dd>
-      
-      
-      
-      
+
+
+
+
       <dt>Editors:</dt><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:pano@skemu.com">Pano Maria</a> (<a class="p-org org h-org" href="https://skemu.com">Skemu</a>)
   </dd><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:els.devleeschauwer@ugent.be">Els de Vleeschauwer</a> (<a class="p-org org h-org" href="https://idlab.technology/">Ghent University – imec – IDLab</a>)
   </dd>
-      
+
       <dt>Authors:</dt><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:pano@skemu.com">Pano Maria</a> (<a class="p-org org h-org" href="https://skemu.com">Skemu</a>)
   </dd><dd class="editor p-author h-card vcard">
@@ -374,28 +374,28 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   </dd><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:dalanti@unibz.it">Davide Lanti</a> (<a class="p-org org h-org" href="https://www.unibz.it/">Free University of Bozen-Bolzano</a>)
   </dd>
-      
+
       <dt>This Version</dt><dd>
-    <a href="https://w3id.org/rml/lv/spec/20250328/">https://w3id.org/rml/lv/spec/20250328/</a>
+    <a href="https://kg-construct.github.io/rml-lv/spec/docs/20250328/">https://kg-construct.github.io/rml-lv/spec/docs/20250328/</a>
   </dd><dt>Previous Version</dt><dd>
-    <a href="https://w3id.org/rml/lv/spec/20250218/">https://w3id.org/rml/lv/spec/20250218/</a>
+    <a href="https://kg-construct.github.io/rml-lv/spec/docs/20250218/">https://kg-construct.github.io/rml-lv/spec/docs/20250218/</a>
   </dd><dt>Website</dt><dd>
     <a href="https://github.com/kg-construct/rml-lv/">https://github.com/kg-construct/rml-lv/</a>
   </dd>
     </dl>
-    
+
     <p class="copyright">
           <a href="https://www.w3.org/policies/#copyright">Copyright</a>
           ©
           2024-2025
-          
+
           the Contributors to the RML Logical Views
           Specification, published by the
           <a href="https://www.w3.org/groups/cg/kg-construct">Knowledge Graph Construction Community Group</a> under the
           <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>. A human-readable
                 <a href="https://www.w3.org/community/about/agreements/cla-deed/">summary</a>
                 is available.
-              
+
         </p>
     <hr title="Separator for header">
   </div>
@@ -414,11 +414,11 @@ as well as additional information about their fields, through structural annotat
       This specification was published by the
       <a href="https://www.w3.org/groups/cg/kg-construct">Knowledge Graph Construction Community Group</a>. It is not a W3C Standard nor is it
       on the W3C Standards Track.
-      
+
             Please note that under the
             <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>
             there is a limited opt-out and other conditions apply.
-          
+
       Learn more about
       <a href="https://www.w3.org/community/">W3C Community and Business Groups</a>.
     </p>
@@ -429,7 +429,7 @@ yet efforts are made to keep things stable.</p>
 
 <section id="overview-0"><div class="header-wrapper"><h2 id="overview"><bdi class="secno">1. </bdi>Overview</h2><a class="self-link" href="#overview" aria-label="Permalink for Section 1."></a></div><p><em>This section is non-normative.</em></p>
 <section id="document-conventions"><div class="header-wrapper"><h3 id="conventions"><bdi class="secno">1.1 </bdi>Document conventions</h3><a class="self-link" href="#conventions" aria-label="Permalink for Section 1.1"></a></div><p>We assume readers have basic familiarity with RDF and RML concepts.</p>
-<p>In this document, examples assume 
+<p>In this document, examples assume
 the following namespace prefix bindings unless otherwise stated:</p>
 <table>
 <thead>
@@ -479,18 +479,18 @@ the following namespace prefix bindings unless otherwise stated:</p>
 <section id="problem-0"><div class="header-wrapper"><h2 id="problem"><bdi class="secno">2. </bdi>Problem</h2><a class="self-link" href="#problem" aria-label="Permalink for Section 2."></a></div><p><em>This section is non-normative.</em></p>
 <p>RML Logical Views aims to resolve challenges such as handling hierarchy of nested data, more flexible joining (also across data hierarchies), and handling data sources that mix source formats.</p>
 <section id="nested-data-structures"><div class="header-wrapper"><h3 id="x2-1-nested-data-structures"><bdi class="secno">2.1 </bdi>Nested data structures</h3><a class="self-link" href="#nested-data-structures" aria-label="Permalink for Section 2.1"></a></div>
-<p>References to nested data structures, like JSON or XML, may return multiple values. These values can be composite: they may again contain multiple values. 
-[<cite><a class="bibref" data-link-type="biblio" href="#bib-rml-core" title="RML-Core">RML-Core</a></cite>] defines mapping constructs that produce results by combining the results of other mapping constructs in a specific order. 
-For example, a <a href="https://w3id.org/rml/core/spec#dfn-triples-map">triples map</a> combines the results of a <a href="https://w3id.org/rml/core/spec#dfn-subject-map">subject map</a> and a <a href="https://w3id.org/rml/core/spec#dfn-predicate-object-map">predicate-object map</a> in that order. 
-Another example is a <a href="https://w3id.org/rml/core/spec#dfn-template-expression">template expression</a>, 
-which combines character strings and zero or more <a href="https://w3id.org/rml/core/spec#dfn-reference-expression">reference expressions</a> in declared order. 
+<p>References to nested data structures, like JSON or XML, may return multiple values. These values can be composite: they may again contain multiple values.
+[<cite><a class="bibref" data-link-type="biblio" href="#bib-rml-core" title="RML-Core">RML-Core</a></cite>] defines mapping constructs that produce results by combining the results of other mapping constructs in a specific order.
+For example, a <a href="https://w3id.org/rml/core/spec#dfn-triples-map">triples map</a> combines the results of a <a href="https://w3id.org/rml/core/spec#dfn-subject-map">subject map</a> and a <a href="https://w3id.org/rml/core/spec#dfn-predicate-object-map">predicate-object map</a> in that order.
+Another example is a <a href="https://w3id.org/rml/core/spec#dfn-template-expression">template expression</a>,
+which combines character strings and zero or more <a href="https://w3id.org/rml/core/spec#dfn-reference-expression">reference expressions</a> in declared order.
 When mapping constructs produce multiple results, the combining mapping constructs will apply an <a href="https://w3id.org/rml/core/spec#dfn-n-ary-cartesian-product">n-ary Cartesian product</a> over the sets of results, maintaining the order of the mapping constructs. In the case of nested data structures, this may cause the generation of results that do not match the source hierarchy, i.e. do not follow the root-to-leaf paths in the source data, since values are combined irrespective of it.</p>
 <p>Furthermore, there is varying expressiveness in data source expression and query languages, and many languages have limited support for hierarchy traversal. For example, JSONPath has no operator to refer to an ancestor in the document hierarchy [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9535" title="JSONPath: Query Expressions for JSON">RFC9535</a></cite>].</p>
 <p>This limits the ability of <a href="https://kg-construct.github.io/rml-core/spec/docs/">RML-Core</a> to map nested data.</p>
 <aside class="example" id="ex-nesting-problem"><div class="marker">
     <a class="self-link" href="#ex-nesting-problem">Example<bdi> 1</bdi></a>
   </div>
-It is not possible to declare the construction of below output triples from below data source with RML-Core. 
+It is not possible to declare the construction of below output triples from below data source with RML-Core.
 <aside class="ex-input">
 
 <pre><code class="json hljs" aria-busy="false"><span class="hljs-punctuation">{</span>
@@ -540,20 +540,20 @@ It is not possible to declare the construction of below output triples from belo
 <aside class="example" id="ex-mixed-format-problem"><div class="marker">
     <a class="self-link" href="#ex-mixed-format-problem">Example<bdi> 2</bdi></a>
   </div>
-It is not possible to declare the construction of below output triples from below data source with RML-Core. 
+It is not possible to declare the construction of below output triples from below data source with RML-Core.
 <aside class="ex-input">
 
-<pre><code class="csv hljs" aria-busy="false">name,item  
-alice,"{""type"":""sword"",""weight"": 2500}" 
-alice,"{""type"":""shield"",""weight"": 1500}"  
-bob,"{""type"":""flower"",""weight"": 15 }"  
+<pre><code class="csv hljs" aria-busy="false">name,item
+alice,"{""type"":""sword"",""weight"": 2500}"
+alice,"{""type"":""shield"",""weight"": 1500}"
+bob,"{""type"":""flower"",""weight"": 15 }"
 </code></pre>
 </aside>
 
 <aside class="ex-output">
 
 <pre><code class="turtle hljs" aria-busy="false">:person/alice :hasItem "sword" , "shield" .
-:person/bob :hasItem "flower" . 
+:person/bob :hasItem "flower" .
 </code></pre>
 </aside>
 </aside>
@@ -564,7 +564,7 @@ Moreover, <a href="https://kg-construct.github.io/rml-core/spec/docs/">RML-Core<
 <aside class="example" id="ex-mixed-format-problem"><div class="marker">
     <a class="self-link" href="#ex-mixed-format-problem">Example<bdi> 3</bdi></a>
   </div>
-It is not possible to declare the construction of below output triples from below two data sources with RML-Core. 
+It is not possible to declare the construction of below output triples from below two data sources with RML-Core.
 <aside class="ex-input">
 
 <pre><code class="csv hljs" aria-busy="false">name,id
@@ -585,7 +585,7 @@ bob,flower
 
 <aside class="ex-output">
 
-<pre><code class="turtle hljs" aria-busy="false">:person/123 :hasItem "sword", "shield" . 
+<pre><code class="turtle hljs" aria-busy="false">:person/123 :hasItem "sword", "shield" .
 :person/456 :hasItem "flower" .
 </code></pre>
 </aside>
@@ -634,7 +634,7 @@ Each set of key-value pairs represents a <a href="https://w3id.org/rml/core/spec
 A <dfn data-plurals="records" id="dfn-record" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">record</dfn> is either an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-record" class="internalDFN" id="ref-for-dfn-iterable-record-1">iterable record</a> or an <a data-link-type="dfn|abstract-op" href="#dfn-expression-record" class="internalDFN" id="ref-for-dfn-expression-record-1">expression record</a>.</p>
 <p>An <dfn data-plurals="iterable records" id="dfn-iterable-record" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">iterable record</dfn> is a <a href="https://w3id.org/rml/core/spec#dfn-iteration">logical iteration</a>, i.e. an item on which expressions can be evaluated.</p>
 <p>An <dfn data-plurals="expression records" id="dfn-expression-record" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">expression record</dfn> is one element of an <a href="https://w3id.org/rml/core//kg-construct.github.io/rml-core/spec/docs/#https://kg-construct.github.io/rml-core/spec/docs/#dfn-expression-evaluation-result">expression evaluation result</a>.</p>
-<p>A <dfn data-plurals="record keys" id="dfn-record-key" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">record key</dfn> has a <a data-link-type="dfn|abstract-op" href="#dfn-record" class="internalDFN" id="ref-for-dfn-record-2">record</a> as value. 
+<p>A <dfn data-plurals="record keys" id="dfn-record-key" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">record key</dfn> has a <a data-link-type="dfn|abstract-op" href="#dfn-record" class="internalDFN" id="ref-for-dfn-record-2">record</a> as value.
 Each <a data-link-type="dfn|abstract-op" href="#dfn-record-key" class="internalDFN" id="ref-for-dfn-record-key-1">record key</a> is accompanied with an <a data-link-type="dfn|abstract-op" href="#dfn-index-key" class="internalDFN" id="ref-for-dfn-index-key-1">index key</a>.</p>
 <p>An <dfn id="dfn-index-key" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">index key</dfn> has a non-negative integer as value, indicating the zero-based position of the corresponding record.</p>
 <ul>
@@ -877,13 +877,13 @@ The underlined keys represent <a data-link-type="dfn|abstract-op" href="#dfn-ref
 <p>There are two types of fields: an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-1">expression field</a> and an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-1">iterable field</a>.</p>
 <p>An <dfn id="dfn-expression-field" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">expression field</dfn> (<code>rml:ExpressionField</code>) is a type of <a href="https://w3id.org/rml/core/spec#dfn-expression-map">expression map</a>.
 Consequently, an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-2">expression field</a> <em class="rfc2119">MUST</em> have an <a href="https://w3id.org/rml/core/spec#dfn-expressions">expression</a>. </p>
-<p>An <dfn id="dfn-iterable-field" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">iterable field</dfn> (<code>rml:IterableField</code>) is a type of <a href="https://w3id.org/rml/core/spec#dfn-iterable">iterable</a>. 
+<p>An <dfn id="dfn-iterable-field" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">iterable field</dfn> (<code>rml:IterableField</code>) is a type of <a href="https://w3id.org/rml/core/spec#dfn-iterable">iterable</a>.
 Consequently, an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-2">iterable field</a> <em class="rfc2119">MUST</em> have a <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> and a <a href="https://w3id.org/rml/core/spec#dfn-iterator">logical iterator</a>.
 If no reference formulation is declared for an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-3">iterable field</a>, the reference formulation of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-1">parent</a> is implied. </p>
 <section id="field-parents"><div class="header-wrapper"><h3 id="fieldparents"><bdi class="secno">4.1 </bdi>Field parents</h3><a class="self-link" href="#fieldparents" aria-label="Permalink for Section 4.1"></a></div><p>A <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-6">field</a> <em class="rfc2119">MUST</em> have a <dfn id="dfn-parent" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">parent</dfn> that is either the <a href="https://w3id.org/rml/core/spec##dfn-abstract-logical-source">abstract logical source</a> of the <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-8">logical view</a> or another <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-7">field</a>. The parent relation <em class="rfc2119">MUST</em> not contain cycles: it is tree-shaped with a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-9">logical view</a> as its root. The transitive parents of a <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-8">field</a>, i.e., the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-9">field</a>'s parent, the parent of the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-10">field</a>'s parent, etcetera, are fittingly called the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-11">field</a>'s <dfn id="dfn-ancestors" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn" class="respec-offending-element" title="Found definition for &quot;ancestors&quot;, but nothing links to it. This is usually a spec bug!">ancestors</dfn>. </p>
-</section><section id="field-names"><div class="header-wrapper"><h3 id="fieldnames"><bdi class="secno">4.2 </bdi>Field names</h3><a class="self-link" href="#fieldnames" aria-label="Permalink for Section 4.2"></a></div><p>A <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-12">field</a> <em class="rfc2119">MUST</em> have a <dfn id="dfn-declared-name" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">declared name</dfn> that is an alphanumerical string. Fields with the same <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-2">parent</a> <em class="rfc2119">MUST</em> have different declared names. 
-We distinguish between the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-13">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-2">declared name</a> and the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-14">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-absolute-name" class="internalDFN" id="ref-for-dfn-absolute-name-1">absolute name</a>. 
-If a <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-15">field</a>'s parent is another <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-16">field</a>, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-17">field</a>'s <dfn id="dfn-absolute-name" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">absolute name</dfn> is the concatenation of the name of the parent <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-18">field</a>, a dot <code>.</code>, and the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-19">field</a>'s declared name. 
+</section><section id="field-names"><div class="header-wrapper"><h3 id="fieldnames"><bdi class="secno">4.2 </bdi>Field names</h3><a class="self-link" href="#fieldnames" aria-label="Permalink for Section 4.2"></a></div><p>A <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-12">field</a> <em class="rfc2119">MUST</em> have a <dfn id="dfn-declared-name" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">declared name</dfn> that is an alphanumerical string. Fields with the same <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-2">parent</a> <em class="rfc2119">MUST</em> have different declared names.
+We distinguish between the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-13">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-2">declared name</a> and the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-14">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-absolute-name" class="internalDFN" id="ref-for-dfn-absolute-name-1">absolute name</a>.
+If a <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-15">field</a>'s parent is another <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-16">field</a>, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-17">field</a>'s <dfn id="dfn-absolute-name" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">absolute name</dfn> is the concatenation of the name of the parent <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-18">field</a>, a dot <code>.</code>, and the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-19">field</a>'s declared name.
 Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-20">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-absolute-name" class="internalDFN" id="ref-for-dfn-absolute-name-2">absolute name</a> equals its <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-3">declared name</a>.  </p>
 <aside class="example" id="ex-fieldnames"><div class="marker">
     <a class="self-link" href="#ex-fieldnames">Example<bdi> 5</bdi></a>
@@ -926,7 +926,7 @@ Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="inte
   <span class="hljs-symbol">rml:source</span> <span class="hljs-symbol">:jsonFile</span> ;
   <span class="hljs-symbol">rml:referenceFormulation</span> <span class="hljs-symbol">rml:JSONPath</span> ;
   <span class="hljs-symbol">rml:iterator</span> <span class="hljs-string">"$.people[*]"</span> .
-  
+
 <span class="hljs-symbol">:jsonView</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalView</span> ;
   <span class="hljs-symbol">rml:viewOn</span> <span class="hljs-symbol">:jsonSource</span> ;
   <span class="hljs-symbol">rml:field</span> [
@@ -1018,12 +1018,12 @@ Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="inte
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item"</span> ;
     <span class="hljs-symbol">rml:iterator</span> <span class="hljs-string">"$.items[*]"</span> ;
     <span class="hljs-symbol">rml:field</span> [
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"type"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"$.type"</span> ;
     ] ;
     <span class="hljs-symbol">rml:field</span> [
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"weight"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"$.weight"</span> ;
     ] ;
@@ -1036,7 +1036,7 @@ Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="inte
 <table>
     <tbody><tr>
         <th><u>#</u></th>
-        <th>&lt;it&gt;</th>   
+        <th>&lt;it&gt;</th>
         <th><u>name.#</u></th>
         <th><u>name</u></th>
         <th><u>item.#</u></th>
@@ -1044,7 +1044,7 @@ Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="inte
         <th><u>item.type.#</u></th>
         <th><u>item.type</u></th>
         <th><u>item.weight.#</u></th>
-        <th><u>item.weight</u></th> 
+        <th><u>item.weight</u></th>
     </tr>
     <tr>
         <td>0</td>
@@ -1067,7 +1067,7 @@ Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="inte
         <td>0</td>
         <td>sword</td>
         <td>0</td>
-        <td>1500</td> 
+        <td>1500</td>
     </tr>
     <tr>
     <td>0</td>
@@ -1121,9 +1121,9 @@ Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="inte
 
 </aside>
 
-</section><section id="field-reference-formulations"><div class="header-wrapper"><h3 id="fieldreferenceformulations"><bdi class="secno">4.4 </bdi>Field reference formulations</h3><a class="self-link" href="#fieldreferenceformulations" aria-label="Permalink for Section 4.4"></a></div><p>For the evaluation of the expression of an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-4">expression field</a> (<code>rml:ExpressionField</code>) on the records of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-4">parent</a>, the parent's <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> is used. 
+</section><section id="field-reference-formulations"><div class="header-wrapper"><h3 id="fieldreferenceformulations"><bdi class="secno">4.4 </bdi>Field reference formulations</h3><a class="self-link" href="#fieldreferenceformulations" aria-label="Permalink for Section 4.4"></a></div><p>For the evaluation of the expression of an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-4">expression field</a> (<code>rml:ExpressionField</code>) on the records of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-4">parent</a>, the parent's <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> is used.
 Consequently, the parent of an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-5">expression field</a> <em class="rfc2119">MUST</em> be an <a href="https://w3id.org/rml/core/spec##dfn-iterable">iterable</a>, i.e. an <a href="https://w3id.org/rml/core/spec##dfn-abstract-logical-source">abstract logical source</a> or <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-5">iterable field</a>.  </p>
-<p>The default <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-6">iterable field</a> (<code>rml:IterableField</code>) is the <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-5">parent</a>. 
+<p>The default <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-6">iterable field</a> (<code>rml:IterableField</code>) is the <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-5">parent</a>.
 If the <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-7">iterable field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-6">parent</a> is an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-6">expression field</a>, a <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> <em class="rfc2119">MUST</em> be declared for the <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-8">iterable field</a>.
 Declaring a new <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a>, i.e. a <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> that is different from the <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-7">parent</a>, is only allowed when the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-8">parent</a> is an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-7">expression field</a>. </p>
 <aside class="example" id="ex-mixed-format-json-csv"><div class="marker">
@@ -1132,8 +1132,8 @@ Declaring a new <a href="https://w3id.org/rml/core/spec##dfn-reference-formulati
 
 <p>In this example a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-12">logical view</a> is defined on a <a href="https://w3id.org/rml/core/spec#dfn-logical-source">logical source</a> with reference formulation <code>rml:JSONPath</code>.
 The <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-28">field</a> with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-7">declared name</a> "items" is evaluated using this <a href="https://w3id.org/rml/core/spec#dfn-reference-formulation">reference formulation</a>.
-The nested <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-29">field</a> with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-8">declared name</a> "item" has a declared <a href="https://w3id.org/rml/core/spec#dfn-reference-formulation">reference formulation</a> <code>rml:CSV</code> and CSV row as implicit iterator. 
-Its records are a sequence of logical iterations defined by its iterator. 
+The nested <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-29">field</a> with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-8">declared name</a> "item" has a declared <a href="https://w3id.org/rml/core/spec#dfn-reference-formulation">reference formulation</a> <code>rml:CSV</code> and CSV row as implicit iterator.
+Its records are a sequence of logical iterations defined by its iterator.
 The nested fields with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-9">declared name</a> "type" and "weight" are evaluated using the reference formulation <code>rml:CSV</code> from their parent field with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-10">declared name</a> "item".</p>
 <pre><code class="json hljs" aria-busy="false"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"people"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
@@ -1146,7 +1146,7 @@ The nested fields with <a data-link-type="dfn|abstract-op" href="#dfn-declared-n
       <span class="hljs-attr">"items"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"type,weight\nflower,15"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">]</span>
-<span class="hljs-punctuation">}</span>  
+<span class="hljs-punctuation">}</span>
 </code></pre>
 </aside>
 <aside class="ex-mapping">
@@ -1158,24 +1158,24 @@ The nested fields with <a data-link-type="dfn|abstract-op" href="#dfn-declared-n
 
 <span class="hljs-symbol">:mixedJSONView</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalView</span> ;
   <span class="hljs-symbol">rml:viewOn</span> <span class="hljs-symbol">:mixedJSONSource</span> ;
-  <span class="hljs-symbol">rml:field</span> [ 
+  <span class="hljs-symbol">rml:field</span> [
     <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"items"</span> ;
     <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"$.items"</span> ;
-    <span class="hljs-symbol">rml:field</span> [ 
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:IterableField</span> ; 
+    <span class="hljs-symbol">rml:field</span> [
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:IterableField</span> ;
       <span class="hljs-symbol">rml:referenceFormulation</span> <span class="hljs-symbol">rml:CSV;</span>
-      <span class="hljs-symbol">rml:field</span> [ 
-        <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-symbol">rml:field</span> [
+        <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
         <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"type"</span> ;
         <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"type"</span> ;
       ] ;
-      <span class="hljs-symbol">rml:field</span> [ 
+      <span class="hljs-symbol">rml:field</span> [
         <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField;</span>
         <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"weight"</span> ;
         <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"weight"</span> ;
       ] ;
-    ] ; 
+    ] ;
   ] .
 </code></pre>
 </aside>
@@ -1292,8 +1292,8 @@ The <a data-link-type="dfn|abstract-op" href="#dfn-parent-logical-view" class="i
     <a class="self-link" href="#ex-leftjoin">Example<bdi> 8</bdi></a>
   </div>
 
-<p>In this example a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-15">logical view</a> with fields built with data from the logical source <code>:csvSource</code> is joined with the logical view from <a href="#ex-field-record-sequence" data-matched-text="[[[#ex-field-record-sequence]]]" class="box-ref">Example<bdi> 6</bdi></a>. 
-In case of a left join (as in the example), this results in 4 logical iterations in the logical view. 
+<p>In this example a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-15">logical view</a> with fields built with data from the logical source <code>:csvSource</code> is joined with the logical view from <a href="#ex-field-record-sequence" data-matched-text="[[[#ex-field-record-sequence]]]" class="box-ref">Example<bdi> 6</bdi></a>.
+In case of a left join (as in the example), this results in 4 logical iterations in the logical view.
 If an inner joins would have been used, the logical view would have only 3 logical iterations. </p>
 <aside class="ex-input">
 
@@ -1309,11 +1309,11 @@ tobias,2005
 <pre><code class="turtle hljs" aria-busy="false"><span class="hljs-symbol">:csvSource</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalSource</span> ;
   <span class="hljs-symbol">rml:source</span> <span class="hljs-symbol">:csvFile</span> ;
   <span class="hljs-symbol">rml:referenceFormulation</span> <span class="hljs-symbol">rml:CSV</span> .
-  
+
 <span class="hljs-symbol">:csvView</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalView</span> ;
   <span class="hljs-symbol">rml:viewOn</span> <span class="hljs-symbol">:csvSource</span> ;
   <span class="hljs-symbol">rml:field</span> [
-    <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+    <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"name"</span> ;
     <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"name"</span> ;
   ] ;
@@ -1327,9 +1327,9 @@ tobias,2005
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_type"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"item.type"</span> ;
     ] ;
@@ -1459,7 +1459,7 @@ tobias,2005
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
       <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_type"</span> ;
@@ -1581,7 +1581,7 @@ tobias,789
     <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"id"</span> ;
     <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"id"</span> ;
-  ] . 
+  ] .
 
 <span class="hljs-symbol">:csvView</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalView</span> ;
   <span class="hljs-symbol">rml:viewOn</span> <span class="hljs-symbol">:csvSource</span> ;
@@ -1600,7 +1600,7 @@ tobias,789
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
       <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_type"</span> ;
@@ -1611,13 +1611,13 @@ tobias,789
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_weight"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"item.weight"</span> ;
     ] ;
-  ] ; 
+  ] ;
   <span class="hljs-symbol">rml:leftJoin</span> [
     <span class="hljs-symbol">rml:parentLogicalView</span> <span class="hljs-symbol">:additionalCsvView</span> ;
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
       <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"id"</span> ;
@@ -1679,7 +1679,7 @@ tobias,789
 <pre><code class="json hljs" aria-busy="false">
 {...}
 </code></pre>
-</td>        
+</td>
         <td>0</td>
         <td>shield</td>
         <td>0</td>
@@ -2016,7 +2016,7 @@ Note that every <a data-link-type="dfn|abstract-op" href="#dfn-foreignkey-annota
 
 
 <section id="references" class="appendix"><div class="header-wrapper"><h2 id="a-references"><bdi class="secno">A. </bdi>References</h2><a class="self-link" href="#references" aria-label="Permalink for Appendix A."></a></div><section id="normative-references"><div class="header-wrapper"><h3 id="a-1-normative-references"><bdi class="secno">A.1 </bdi>Normative references</h3><a class="self-link" href="#normative-references" aria-label="Permalink for Appendix A.1"></a></div>
-    
+
     <dl class="bibliography"><dt id="bib-rfc2119">[RFC2119]</dt><dd>
       <a href="https://www.rfc-editor.org/rfc/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a>
     </dd><dt id="bib-rfc8174">[RFC8174]</dt><dd>
@@ -2034,257 +2034,257 @@ Note that every <a data-link-type="dfn|abstract-op" href="#dfn-foreignkey-annota
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view" aria-label="Permalink for definition: logical view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-1" title="§ 3. Logical views">§ 3. Logical views</a> <a href="#ref-for-dfn-logical-view-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-1" title="§ 3. Logical views">§ 3. Logical views</a> <a href="#ref-for-dfn-logical-view-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-3" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-4" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-5" title="Reference 3">(3)</a> <a href="#ref-for-dfn-logical-view-6" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-logical-view-3" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-4" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-5" title="Reference 3">(3)</a> <a href="#ref-for-dfn-logical-view-6" title="Reference 4">(4)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-7" title="§ 4. Fields">§ 4. Fields</a> 
+      <a href="#ref-for-dfn-logical-view-7" title="§ 4. Fields">§ 4. Fields</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-8" title="§ 4.1 Field parents">§ 4.1 Field parents</a> <a href="#ref-for-dfn-logical-view-9" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-8" title="§ 4.1 Field parents">§ 4.1 Field parents</a> <a href="#ref-for-dfn-logical-view-9" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-10" title="§ 4.2 Field names">§ 4.2 Field names</a> 
+      <a href="#ref-for-dfn-logical-view-10" title="§ 4.2 Field names">§ 4.2 Field names</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-11" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-logical-view-11" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-12" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> 
+      <a href="#ref-for-dfn-logical-view-12" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-13" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-logical-view-14" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-13" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-logical-view-14" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-15" title="§ 5.2.1 Left join">§ 5.2.1 Left join</a> 
+      <a href="#ref-for-dfn-logical-view-15" title="§ 5.2.1 Left join">§ 5.2.1 Left join</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-16" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a> 
+      <a href="#ref-for-dfn-logical-view-16" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-17" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-logical-view-17" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-18" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a> 
+      <a href="#ref-for-dfn-logical-view-18" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-19" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-logical-view-19" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-20" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> 
+      <a href="#ref-for-dfn-logical-view-20" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-logical-view-iteration-sequence" aria-label="Links in this document to definition: logical view iteration sequence">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view-iteration-sequence" aria-label="Permalink for definition: logical view iteration sequence. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-iteration-sequence-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-iteration-sequence-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-sequence-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-iteration-sequence-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-iteration-sequence-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-logical-view-iteration-sequence-4" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-sequence-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-logical-view-iteration-sequence-4" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-iteration-sequence-5" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-sequence-5" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-logical-view-iteration" aria-label="Links in this document to definition: logical view iteration">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view-iteration" aria-label="Permalink for definition: logical view iteration. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-iteration-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-iteration-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-iteration-3" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-iteration-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-iteration-3" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-iteration-4" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-4" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-record" aria-label="Links in this document to definition: record">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-record" aria-label="Permalink for definition: record. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-record-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-record-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-record-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> 
+      <a href="#ref-for-dfn-record-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a>
     </li><li>
-      <a href="#ref-for-dfn-record-4" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-record-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-record-7" title="Reference 4">(4)</a> <a href="#ref-for-dfn-record-8" title="Reference 5">(5)</a> 
+      <a href="#ref-for-dfn-record-4" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-record-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-record-7" title="Reference 4">(4)</a> <a href="#ref-for-dfn-record-8" title="Reference 5">(5)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-iterable-record" aria-label="Links in this document to definition: iterable record">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-iterable-record" aria-label="Permalink for definition: iterable record. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-iterable-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-iterable-record-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-record-3" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-iterable-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-iterable-record-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-record-3" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-iterable-record-4" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> 
+      <a href="#ref-for-dfn-iterable-record-4" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a>
     </li><li>
-      <a href="#ref-for-dfn-iterable-record-5" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-iterable-record-5" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-expression-record" aria-label="Links in this document to definition: expression record">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-expression-record" aria-label="Permalink for definition: expression record. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-expression-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-expression-record-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-expression-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-expression-record-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-record-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-expression-record-4" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-expression-record-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-expression-record-4" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-record-5" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-expression-record-5" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-record-key" aria-label="Links in this document to definition: record key">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-record-key" aria-label="Permalink for definition: record key. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-record-key-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-record-key-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-key-3" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-record-key-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-record-key-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-key-3" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-record-key-4" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-record-key-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-key-6" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-record-key-4" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-record-key-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-key-6" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-record-key-7" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-record-key-7" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-index-key" aria-label="Links in this document to definition: index key">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-index-key" aria-label="Permalink for definition: index key. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-index-key-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-index-key-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-index-key-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-index-key-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-index-key-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-index-key-4" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-index-key-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-index-key-4" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-index-key-5" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-index-key-5" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-logical-view-reference" aria-label="Links in this document to definition: logical view reference">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view-reference" aria-label="Permalink for definition: logical view reference. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-reference-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-logical-view-reference-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-reference-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-logical-view-reference-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-reference-3" title="§ 5. Logical view joins">§ 5. Logical view joins</a> 
+      <a href="#ref-for-dfn-logical-view-reference-3" title="§ 5. Logical view joins">§ 5. Logical view joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-referenceable-key" aria-label="Links in this document to definition: referenceable key">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-referenceable-key" aria-label="Permalink for definition: referenceable key. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-referenceable-key-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-referenceable-key-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-referenceable-key-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-referenceable-key-2" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-field" aria-label="Links in this document to definition: field">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-field" aria-label="Permalink for definition: field. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-field-1" title="§ 3. Logical views">§ 3. Logical views</a> <a href="#ref-for-dfn-field-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-field-1" title="§ 3. Logical views">§ 3. Logical views</a> <a href="#ref-for-dfn-field-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-3" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> 
+      <a href="#ref-for-dfn-field-3" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a>
     </li><li>
-      <a href="#ref-for-dfn-field-4" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-field-5" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-field-4" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-field-5" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-6" title="§ 4.1 Field parents">§ 4.1 Field parents</a> <a href="#ref-for-dfn-field-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-9" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-10" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-11" title="Reference 6">(6)</a> 
+      <a href="#ref-for-dfn-field-6" title="§ 4.1 Field parents">§ 4.1 Field parents</a> <a href="#ref-for-dfn-field-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-9" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-10" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-11" title="Reference 6">(6)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-12" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-field-13" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-14" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-15" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-16" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-17" title="Reference 6">(6)</a> <a href="#ref-for-dfn-field-18" title="Reference 7">(7)</a> <a href="#ref-for-dfn-field-19" title="Reference 8">(8)</a> <a href="#ref-for-dfn-field-20" title="Reference 9">(9)</a> <a href="#ref-for-dfn-field-21" title="Reference 10">(10)</a> 
+      <a href="#ref-for-dfn-field-12" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-field-13" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-14" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-15" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-16" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-17" title="Reference 6">(6)</a> <a href="#ref-for-dfn-field-18" title="Reference 7">(7)</a> <a href="#ref-for-dfn-field-19" title="Reference 8">(8)</a> <a href="#ref-for-dfn-field-20" title="Reference 9">(9)</a> <a href="#ref-for-dfn-field-21" title="Reference 10">(10)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-22" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-field-23" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-24" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-25" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-26" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-27" title="Reference 6">(6)</a> 
+      <a href="#ref-for-dfn-field-22" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-field-23" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-24" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-25" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-26" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-27" title="Reference 6">(6)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-28" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-field-29" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-field-28" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-field-29" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-expression-field" aria-label="Links in this document to definition: expression field">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-expression-field" aria-label="Permalink for definition: expression field. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-expression-field-1" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-expression-field-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-expression-field-1" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-expression-field-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-field-3" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-expression-field-3" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-field-4" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-expression-field-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-expression-field-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-expression-field-7" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-expression-field-4" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-expression-field-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-expression-field-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-expression-field-7" title="Reference 4">(4)</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-field-8" title="§ 5. Logical view joins">§ 5. Logical view joins</a> 
+      <a href="#ref-for-dfn-expression-field-8" title="§ 5. Logical view joins">§ 5. Logical view joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-iterable-field" aria-label="Links in this document to definition: iterable field">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-iterable-field" aria-label="Permalink for definition: iterable field. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-iterable-field-1" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-iterable-field-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-field-3" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-iterable-field-1" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-iterable-field-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-field-3" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-iterable-field-4" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-iterable-field-4" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-iterable-field-5" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-iterable-field-6" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-field-7" title="Reference 3">(3)</a> <a href="#ref-for-dfn-iterable-field-8" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-iterable-field-5" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-iterable-field-6" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-field-7" title="Reference 3">(3)</a> <a href="#ref-for-dfn-iterable-field-8" title="Reference 4">(4)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-parent" aria-label="Links in this document to definition: parent">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-parent" aria-label="Permalink for definition: parent. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-parent-1" title="§ 4. Fields">§ 4. Fields</a> 
+      <a href="#ref-for-dfn-parent-1" title="§ 4. Fields">§ 4. Fields</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-2" title="§ 4.2 Field names">§ 4.2 Field names</a> 
+      <a href="#ref-for-dfn-parent-2" title="§ 4.2 Field names">§ 4.2 Field names</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-3" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-parent-3" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-4" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-parent-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-parent-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-parent-7" title="Reference 4">(4)</a> <a href="#ref-for-dfn-parent-8" title="Reference 5">(5)</a> 
+      <a href="#ref-for-dfn-parent-4" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-parent-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-parent-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-parent-7" title="Reference 4">(4)</a> <a href="#ref-for-dfn-parent-8" title="Reference 5">(5)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-ancestors" aria-label="Links in this document to definition: ancestors">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-ancestors" aria-label="Permalink for definition: ancestors. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
@@ -2294,280 +2294,280 @@ Note that every <a data-link-type="dfn|abstract-op" href="#dfn-foreignkey-annota
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-declared-name" aria-label="Permalink for definition: declared name. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-declared-name-1" title="§ 4. Fields">§ 4. Fields</a> 
+      <a href="#ref-for-dfn-declared-name-1" title="§ 4. Fields">§ 4. Fields</a>
     </li><li>
-      <a href="#ref-for-dfn-declared-name-2" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-declared-name-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-declared-name-4" title="Reference 3">(3)</a> <a href="#ref-for-dfn-declared-name-5" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-declared-name-2" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-declared-name-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-declared-name-4" title="Reference 3">(3)</a> <a href="#ref-for-dfn-declared-name-5" title="Reference 4">(4)</a>
     </li><li>
-      <a href="#ref-for-dfn-declared-name-6" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-declared-name-6" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-declared-name-7" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-declared-name-8" title="Reference 2">(2)</a> <a href="#ref-for-dfn-declared-name-9" title="Reference 3">(3)</a> <a href="#ref-for-dfn-declared-name-10" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-declared-name-7" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-declared-name-8" title="Reference 2">(2)</a> <a href="#ref-for-dfn-declared-name-9" title="Reference 3">(3)</a> <a href="#ref-for-dfn-declared-name-10" title="Reference 4">(4)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-absolute-name" aria-label="Links in this document to definition: absolute name">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-absolute-name" aria-label="Permalink for definition: absolute name. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-absolute-name-1" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-absolute-name-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-absolute-name-1" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-absolute-name-2" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-parent-records" aria-label="Links in this document to definition: parent records">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-parent-records" aria-label="Permalink for definition: parent records. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-parent-records-1" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-parent-records-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-parent-records-1" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-parent-records-2" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-logical-view-join" aria-label="Links in this document to definition: logical view join">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view-join" aria-label="Permalink for definition: logical view join. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-join-1" title="§ 3. Logical views">§ 3. Logical views</a> 
+      <a href="#ref-for-dfn-logical-view-join-1" title="§ 3. Logical views">§ 3. Logical views</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-join-2" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-logical-view-join-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-join-4" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-logical-view-join-2" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-logical-view-join-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-join-4" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-join-5" title="§ 5.1 Join types">§ 5.1 Join types</a> <a href="#ref-for-dfn-logical-view-join-6" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-join-5" title="§ 5.1 Join types">§ 5.1 Join types</a> <a href="#ref-for-dfn-logical-view-join-6" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-join-7" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a> 
+      <a href="#ref-for-dfn-logical-view-join-7" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-parent-logical-view" aria-label="Links in this document to definition: parent logical view">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-parent-logical-view" aria-label="Permalink for definition: parent logical view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-parent-logical-view-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-parent-logical-view-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-parent-logical-view-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-parent-logical-view-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-logical-view-3" title="§ 5.1 Join types">§ 5.1 Join types</a> 
+      <a href="#ref-for-dfn-parent-logical-view-3" title="§ 5.1 Join types">§ 5.1 Join types</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-logical-view-4" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a> 
+      <a href="#ref-for-dfn-parent-logical-view-4" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-child-logical-view" aria-label="Links in this document to definition: child logical view">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-child-logical-view" aria-label="Permalink for definition: child logical view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-child-logical-view-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a> 
+      <a href="#ref-for-dfn-child-logical-view-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a>
     </li><li>
-      <a href="#ref-for-dfn-child-logical-view-2" title="§ 5.1 Join types">§ 5.1 Join types</a> <a href="#ref-for-dfn-child-logical-view-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-child-logical-view-2" title="§ 5.1 Join types">§ 5.1 Join types</a> <a href="#ref-for-dfn-child-logical-view-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-join-property" aria-label="Links in this document to definition: join property">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-join-property" aria-label="Permalink for definition: join property. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-join-property-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a> 
+      <a href="#ref-for-dfn-join-property-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-left-join" aria-label="Links in this document to definition: left join">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-left-join" aria-label="Permalink for definition: left join. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-left-join-1" title="§ 5.1 Join types">§ 5.1 Join types</a> 
+      <a href="#ref-for-dfn-left-join-1" title="§ 5.1 Join types">§ 5.1 Join types</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-inner-join" aria-label="Links in this document to definition: inner join">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-inner-join" aria-label="Permalink for definition: inner join. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-inner-join-1" title="§ 5.1 Join types">§ 5.1 Join types</a> 
+      <a href="#ref-for-dfn-inner-join-1" title="§ 5.1 Join types">§ 5.1 Join types</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-structural-annotations" aria-label="Links in this document to definition: Structural annotations">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-structural-annotations" aria-label="Permalink for definition: Structural annotations. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-structural-annotations-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> <a href="#ref-for-dfn-structural-annotations-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-structural-annotations-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> <a href="#ref-for-dfn-structural-annotations-2" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-on-fields" aria-label="Links in this document to definition: on fields">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-on-fields" aria-label="Permalink for definition: on fields. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-on-fields-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-on-fields-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-2" title="§ 6.2 IriSafe">§ 6.2 IriSafe</a> 
+      <a href="#ref-for-dfn-on-fields-2" title="§ 6.2 IriSafe">§ 6.2 IriSafe</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-3" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a> 
+      <a href="#ref-for-dfn-on-fields-3" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-4" title="§ 6.4 Unique">§ 6.4 Unique</a> 
+      <a href="#ref-for-dfn-on-fields-4" title="§ 6.4 Unique">§ 6.4 Unique</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-5" title="§ 6.5 NotNull">§ 6.5 NotNull</a> 
+      <a href="#ref-for-dfn-on-fields-5" title="§ 6.5 NotNull">§ 6.5 NotNull</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-6" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> <a href="#ref-for-dfn-on-fields-7" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-on-fields-6" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> <a href="#ref-for-dfn-on-fields-7" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-8" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> 
+      <a href="#ref-for-dfn-on-fields-8" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-irisafe-annotation" aria-label="Links in this document to definition: IriSafe structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-irisafe-annotation" aria-label="Permalink for definition: IriSafe structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-irisafe-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-irisafe-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-primarykey-annotation" aria-label="Links in this document to definition: PrimaryKey structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-primarykey-annotation" aria-label="Permalink for definition: PrimaryKey structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-primarykey-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-primarykey-annotation-2" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-2" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a>
     </li><li>
-      <a href="#ref-for-dfn-primarykey-annotation-3" title="§ 6.4 Unique">§ 6.4 Unique</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-3" title="§ 6.4 Unique">§ 6.4 Unique</a>
     </li><li>
-      <a href="#ref-for-dfn-primarykey-annotation-4" title="§ 6.5 NotNull">§ 6.5 NotNull</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-4" title="§ 6.5 NotNull">§ 6.5 NotNull</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-unique-annotation" aria-label="Links in this document to definition: Unique structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-unique-annotation" aria-label="Permalink for definition: Unique structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-unique-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-unique-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-unique-annotation-2" title="§ 6.4 Unique">§ 6.4 Unique</a> <a href="#ref-for-dfn-unique-annotation-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-unique-annotation-2" title="§ 6.4 Unique">§ 6.4 Unique</a> <a href="#ref-for-dfn-unique-annotation-3" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-unique-annotation-4" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-unique-annotation-4" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-notnull-annotation" aria-label="Links in this document to definition: NotNull structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-notnull-annotation" aria-label="Permalink for definition: NotNull structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-notnull-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-notnull-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-notnull-annotation-2" title="§ 6.5 NotNull">§ 6.5 NotNull</a> <a href="#ref-for-dfn-notnull-annotation-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-notnull-annotation-2" title="§ 6.5 NotNull">§ 6.5 NotNull</a> <a href="#ref-for-dfn-notnull-annotation-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-foreignkey-annotation" aria-label="Links in this document to definition: ForeignKey structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-foreignkey-annotation" aria-label="Permalink for definition: ForeignKey structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-foreignkey-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-foreignkey-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-foreignkey-annotation-2" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-foreignkey-annotation-2" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-foreignkey-annotation-3" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-foreignkey-annotation-4" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-foreignkey-annotation-3" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-foreignkey-annotation-4" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-target-view" aria-label="Links in this document to definition: target view">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-target-view" aria-label="Permalink for definition: target view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-target-view-1" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-target-view-1" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-target-view-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-target-view-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-target-view-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-target-view-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-target-fields" aria-label="Links in this document to definition: target fields">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-target-fields" aria-label="Permalink for definition: target fields. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-target-fields-1" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-target-fields-1" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-target-fields-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> 
+      <a href="#ref-for-dfn-target-fields-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-inclusion-annotation" aria-label="Links in this document to definition: Inclusion structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-inclusion-annotation" aria-label="Permalink for definition: Inclusion structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-inclusion-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-inclusion-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-inclusion-annotation-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-inclusion-annotation-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-inclusion-annotation-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-inclusion-annotation-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><script id="respec-highlight-vars">(() => {

--- a/spec/rendered.html
+++ b/spec/rendered.html
@@ -42,13 +42,13 @@ dfn{cursor:pointer}
 .dfn-panel li{margin-left:1em}
 .dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
 </style>
-    
+
 <title>RML Logical Views</title>
-    
-    
+
+
 <link rel="stylesheet" type="text/css" href="./resources/css/extras.css">
-    
-    
+
+
 <style type="text/css">
 
         /* Adapted from R2RML */
@@ -133,13 +133,13 @@ dfn{cursor:pointer}
         th {
           font-weight: bold;
         }
-    
+
 </style>
-    
-    
-    
+
+
+
 <script data-goatcounter="https://rml-fields.goatcounter.com/count" async="" src="//gc.zgo.at/count.js"></script>
-    
+
 <noscript>
         &lt;img src="https://rml-fields.goatcounter.com/count?p=/test-noscript"&gt;
     </noscript>
@@ -291,7 +291,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     }
   ],
   "group": "kg-construct",
-  "latestVersion": "https://w3id.org/rml/lv/spec/",
+  "latestVersion": "https://kg-construct.github.io/rml-lv/spec/docs/",
   "issueBase": "https://github.com/kg-construct/rml-lv/issues",
   "noRecTrack": "true",
   "otherLinks": [
@@ -299,8 +299,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "key": "This Version",
       "data": [
         {
-          "value": "https://w3id.org/rml/lv/spec/%thisDate%/",
-          "href": "https://w3id.org/rml/lv/spec/%thisDate%/"
+          "value": "https://kg-construct.github.io/rml-lv/spec/docs/%thisDate%/",
+          "href": "https://kg-construct.github.io/rml-lv/spec/docs/%thisDate%/"
         }
       ]
     },
@@ -308,8 +308,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "key": "Previous Version",
       "data": [
         {
-          "value": "https://w3id.org/rml/lv/spec/%prevDate%/",
-          "href": "https://w3id.org/rml/lv/spec/%prevDate%/"
+          "value": "https://kg-construct.github.io/rml-lv/spec/docs/%prevDate%/",
+          "href": "https://kg-construct.github.io/rml-lv/spec/docs/%prevDate%/"
         }
       ]
     },
@@ -345,28 +345,28 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 }</script>
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/cg-draft"></head>
 <body class="h-entry"><div class="head">
-    
-    <h1 id="title" class="title">RML Logical Views</h1> 
+
+    <h1 id="title" class="title">RML Logical Views</h1>
     <p id="w3c-state">
       <a href="https://www.w3.org/standards/types#reports">Draft Community Group Report</a>
       <time class="dt-published" datetime="2025-03-28">28 March 2025</time>
     </p>
     <dl>
-      
+
       <dt>Latest published version:</dt><dd>
-              <a href="https://w3id.org/rml/lv/spec/">https://w3id.org/rml/lv/spec/</a>
+              <a href="https://kg-construct.github.io/rml-lv/spec/docs/">https://kg-construct.github.io/rml-lv/spec/docs/</a>
             </dd>
       <dt>Latest editor's draft:</dt><dd><a href="https://w3id.org/rml/lv/spec">https://w3id.org/rml/lv/spec</a></dd>
-      
-      
-      
-      
+
+
+
+
       <dt>Editors:</dt><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:pano@skemu.com">Pano Maria</a> (<a class="p-org org h-org" href="https://skemu.com">Skemu</a>)
   </dd><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:els.devleeschauwer@ugent.be">Els de Vleeschauwer</a> (<a class="p-org org h-org" href="https://idlab.technology/">Ghent University – imec – IDLab</a>)
   </dd>
-      
+
       <dt>Authors:</dt><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:pano@skemu.com">Pano Maria</a> (<a class="p-org org h-org" href="https://skemu.com">Skemu</a>)
   </dd><dd class="editor p-author h-card vcard">
@@ -374,28 +374,28 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   </dd><dd class="editor p-author h-card vcard">
     <a class="ed_mailto u-email email p-name" href="mailto:dalanti@unibz.it">Davide Lanti</a> (<a class="p-org org h-org" href="https://www.unibz.it/">Free University of Bozen-Bolzano</a>)
   </dd>
-      
+
       <dt>This Version</dt><dd>
-    <a href="https://w3id.org/rml/lv/spec/%thisDate%/">https://w3id.org/rml/lv/spec/%thisDate%/</a>
+    <a href="https://kg-construct.github.io/rml-lv/spec/docs/%thisDate%/">https://kg-construct.github.io/rml-lv/spec/docs/%thisDate%/</a>
   </dd><dt>Previous Version</dt><dd>
-    <a href="https://w3id.org/rml/lv/spec/%prevDate%/">https://w3id.org/rml/lv/spec/%prevDate%/</a>
+    <a href="https://kg-construct.github.io/rml-lv/spec/docs/%prevDate%/">https://kg-construct.github.io/rml-lv/spec/docs/%prevDate%/</a>
   </dd><dt>Website</dt><dd>
     <a href="https://github.com/kg-construct/rml-lv/">https://github.com/kg-construct/rml-lv/</a>
   </dd>
     </dl>
-    
+
     <p class="copyright">
           <a href="https://www.w3.org/policies/#copyright">Copyright</a>
           ©
           2024-2025
-          
+
           the Contributors to the RML Logical Views
           Specification, published by the
           <a href="https://www.w3.org/groups/cg/kg-construct">Knowledge Graph Construction Community Group</a> under the
           <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>. A human-readable
                 <a href="https://www.w3.org/community/about/agreements/cla-deed/">summary</a>
                 is available.
-              
+
         </p>
     <hr title="Separator for header">
   </div>
@@ -414,11 +414,11 @@ as well as additional information about their fields, through structural annotat
       This specification was published by the
       <a href="https://www.w3.org/groups/cg/kg-construct">Knowledge Graph Construction Community Group</a>. It is not a W3C Standard nor is it
       on the W3C Standards Track.
-      
+
             Please note that under the
             <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>
             there is a limited opt-out and other conditions apply.
-          
+
       Learn more about
       <a href="https://www.w3.org/community/">W3C Community and Business Groups</a>.
     </p>
@@ -429,7 +429,7 @@ yet efforts are made to keep things stable.</p>
 
 <section id="overview-0"><div class="header-wrapper"><h2 id="overview"><bdi class="secno">1. </bdi>Overview</h2><a class="self-link" href="#overview" aria-label="Permalink for Section 1."></a></div><p><em>This section is non-normative.</em></p>
 <section id="document-conventions"><div class="header-wrapper"><h3 id="conventions"><bdi class="secno">1.1 </bdi>Document conventions</h3><a class="self-link" href="#conventions" aria-label="Permalink for Section 1.1"></a></div><p>We assume readers have basic familiarity with RDF and RML concepts.</p>
-<p>In this document, examples assume 
+<p>In this document, examples assume
 the following namespace prefix bindings unless otherwise stated:</p>
 <table>
 <thead>
@@ -479,18 +479,18 @@ the following namespace prefix bindings unless otherwise stated:</p>
 <section id="problem-0"><div class="header-wrapper"><h2 id="problem"><bdi class="secno">2. </bdi>Problem</h2><a class="self-link" href="#problem" aria-label="Permalink for Section 2."></a></div><p><em>This section is non-normative.</em></p>
 <p>RML Logical Views aims to resolve challenges such as handling hierarchy of nested data, more flexible joining (also across data hierarchies), and handling data sources that mix source formats.</p>
 <section id="nested-data-structures"><div class="header-wrapper"><h3 id="x2-1-nested-data-structures"><bdi class="secno">2.1 </bdi>Nested data structures</h3><a class="self-link" href="#nested-data-structures" aria-label="Permalink for Section 2.1"></a></div>
-<p>References to nested data structures, like JSON or XML, may return multiple values. These values can be composite: they may again contain multiple values. 
-[<cite><a class="bibref" data-link-type="biblio" href="#bib-rml-core" title="RML-Core">RML-Core</a></cite>] defines mapping constructs that produce results by combining the results of other mapping constructs in a specific order. 
-For example, a <a href="https://w3id.org/rml/core/spec#dfn-triples-map">triples map</a> combines the results of a <a href="https://w3id.org/rml/core/spec#dfn-subject-map">subject map</a> and a <a href="https://w3id.org/rml/core/spec#dfn-predicate-object-map">predicate-object map</a> in that order. 
-Another example is a <a href="https://w3id.org/rml/core/spec#dfn-template-expression">template expression</a>, 
-which combines character strings and zero or more <a href="https://w3id.org/rml/core/spec#dfn-reference-expression">reference expressions</a> in declared order. 
+<p>References to nested data structures, like JSON or XML, may return multiple values. These values can be composite: they may again contain multiple values.
+[<cite><a class="bibref" data-link-type="biblio" href="#bib-rml-core" title="RML-Core">RML-Core</a></cite>] defines mapping constructs that produce results by combining the results of other mapping constructs in a specific order.
+For example, a <a href="https://w3id.org/rml/core/spec#dfn-triples-map">triples map</a> combines the results of a <a href="https://w3id.org/rml/core/spec#dfn-subject-map">subject map</a> and a <a href="https://w3id.org/rml/core/spec#dfn-predicate-object-map">predicate-object map</a> in that order.
+Another example is a <a href="https://w3id.org/rml/core/spec#dfn-template-expression">template expression</a>,
+which combines character strings and zero or more <a href="https://w3id.org/rml/core/spec#dfn-reference-expression">reference expressions</a> in declared order.
 When mapping constructs produce multiple results, the combining mapping constructs will apply an <a href="https://w3id.org/rml/core/spec#dfn-n-ary-cartesian-product">n-ary Cartesian product</a> over the sets of results, maintaining the order of the mapping constructs. In the case of nested data structures, this may cause the generation of results that do not match the source hierarchy, i.e. do not follow the root-to-leaf paths in the source data, since values are combined irrespective of it.</p>
 <p>Furthermore, there is varying expressiveness in data source expression and query languages, and many languages have limited support for hierarchy traversal. For example, JSONPath has no operator to refer to an ancestor in the document hierarchy [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9535" title="JSONPath: Query Expressions for JSON">RFC9535</a></cite>].</p>
 <p>This limits the ability of <a href="https://kg-construct.github.io/rml-core/spec/docs/">RML-Core</a> to map nested data.</p>
 <aside class="example" id="ex-nesting-problem"><div class="marker">
     <a class="self-link" href="#ex-nesting-problem">Example<bdi> 1</bdi></a>
   </div>
-It is not possible to declare the construction of below output triples from below data source with RML-Core. 
+It is not possible to declare the construction of below output triples from below data source with RML-Core.
 <aside class="ex-input">
 
 <pre><code class="json hljs" aria-busy="false"><span class="hljs-punctuation">{</span>
@@ -540,20 +540,20 @@ It is not possible to declare the construction of below output triples from belo
 <aside class="example" id="ex-mixed-format-problem"><div class="marker">
     <a class="self-link" href="#ex-mixed-format-problem">Example<bdi> 2</bdi></a>
   </div>
-It is not possible to declare the construction of below output triples from below data source with RML-Core. 
+It is not possible to declare the construction of below output triples from below data source with RML-Core.
 <aside class="ex-input">
 
-<pre><code class="csv hljs" aria-busy="false">name,item  
-alice,"{""type"":""sword"",""weight"": 2500}" 
-alice,"{""type"":""shield"",""weight"": 1500}"  
-bob,"{""type"":""flower"",""weight"": 15 }"  
+<pre><code class="csv hljs" aria-busy="false">name,item
+alice,"{""type"":""sword"",""weight"": 2500}"
+alice,"{""type"":""shield"",""weight"": 1500}"
+bob,"{""type"":""flower"",""weight"": 15 }"
 </code></pre>
 </aside>
 
 <aside class="ex-output">
 
 <pre><code class="turtle hljs" aria-busy="false">:person/alice :hasItem "sword" , "shield" .
-:person/bob :hasItem "flower" . 
+:person/bob :hasItem "flower" .
 </code></pre>
 </aside>
 </aside>
@@ -564,7 +564,7 @@ Moreover, <a href="https://kg-construct.github.io/rml-core/spec/docs/">RML-Core<
 <aside class="example" id="ex-mixed-format-problem"><div class="marker">
     <a class="self-link" href="#ex-mixed-format-problem">Example<bdi> 3</bdi></a>
   </div>
-It is not possible to declare the construction of below output triples from below two data sources with RML-Core. 
+It is not possible to declare the construction of below output triples from below two data sources with RML-Core.
 <aside class="ex-input">
 
 <pre><code class="csv hljs" aria-busy="false">name,id
@@ -585,7 +585,7 @@ bob,flower
 
 <aside class="ex-output">
 
-<pre><code class="turtle hljs" aria-busy="false">:person/123 :hasItem "sword", "shield" . 
+<pre><code class="turtle hljs" aria-busy="false">:person/123 :hasItem "sword", "shield" .
 :person/456 :hasItem "flower" .
 </code></pre>
 </aside>
@@ -634,7 +634,7 @@ Each set of key-value pairs represents a <a href="https://w3id.org/rml/core/spec
 A <dfn data-plurals="records" id="dfn-record" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">record</dfn> is either an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-record" class="internalDFN" id="ref-for-dfn-iterable-record-1">iterable record</a> or an <a data-link-type="dfn|abstract-op" href="#dfn-expression-record" class="internalDFN" id="ref-for-dfn-expression-record-1">expression record</a>.</p>
 <p>An <dfn data-plurals="iterable records" id="dfn-iterable-record" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">iterable record</dfn> is a <a href="https://w3id.org/rml/core/spec#dfn-iteration">logical iteration</a>, i.e. an item on which expressions can be evaluated.</p>
 <p>An <dfn data-plurals="expression records" id="dfn-expression-record" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">expression record</dfn> is one element of an <a href="https://w3id.org/rml/core//kg-construct.github.io/rml-core/spec/docs/#https://kg-construct.github.io/rml-core/spec/docs/#dfn-expression-evaluation-result">expression evaluation result</a>.</p>
-<p>A <dfn data-plurals="record keys" id="dfn-record-key" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">record key</dfn> has a <a data-link-type="dfn|abstract-op" href="#dfn-record" class="internalDFN" id="ref-for-dfn-record-2">record</a> as value. 
+<p>A <dfn data-plurals="record keys" id="dfn-record-key" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">record key</dfn> has a <a data-link-type="dfn|abstract-op" href="#dfn-record" class="internalDFN" id="ref-for-dfn-record-2">record</a> as value.
 Each <a data-link-type="dfn|abstract-op" href="#dfn-record-key" class="internalDFN" id="ref-for-dfn-record-key-1">record key</a> is accompanied with an <a data-link-type="dfn|abstract-op" href="#dfn-index-key" class="internalDFN" id="ref-for-dfn-index-key-1">index key</a>.</p>
 <p>An <dfn id="dfn-index-key" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">index key</dfn> has a non-negative integer as value, indicating the zero-based position of the corresponding record.</p>
 <ul>
@@ -877,13 +877,13 @@ The underlined keys represent <a data-link-type="dfn|abstract-op" href="#dfn-ref
 <p>There are two types of fields: an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-1">expression field</a> and an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-1">iterable field</a>.</p>
 <p>An <dfn id="dfn-expression-field" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">expression field</dfn> (<code>rml:ExpressionField</code>) is a type of <a href="https://w3id.org/rml/core/spec#dfn-expression-map">expression map</a>.
 Consequently, an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-2">expression field</a> <em class="rfc2119">MUST</em> have an <a href="https://w3id.org/rml/core/spec#dfn-expressions">expression</a>. </p>
-<p>An <dfn id="dfn-iterable-field" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">iterable field</dfn> (<code>rml:IterableField</code>) is a type of <a href="https://w3id.org/rml/core/spec#dfn-iterable">iterable</a>. 
+<p>An <dfn id="dfn-iterable-field" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">iterable field</dfn> (<code>rml:IterableField</code>) is a type of <a href="https://w3id.org/rml/core/spec#dfn-iterable">iterable</a>.
 Consequently, an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-2">iterable field</a> <em class="rfc2119">MUST</em> have a <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> and a <a href="https://w3id.org/rml/core/spec#dfn-iterator">logical iterator</a>.
 If no reference formulation is declared for an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-3">iterable field</a>, the reference formulation of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-1">parent</a> is implied. </p>
 <section id="field-parents"><div class="header-wrapper"><h3 id="fieldparents"><bdi class="secno">4.1 </bdi>Field parents</h3><a class="self-link" href="#fieldparents" aria-label="Permalink for Section 4.1"></a></div><p>A <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-6">field</a> <em class="rfc2119">MUST</em> have a <dfn id="dfn-parent" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">parent</dfn> that is either the <a href="https://w3id.org/rml/core/spec##dfn-abstract-logical-source">abstract logical source</a> of the <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-8">logical view</a> or another <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-7">field</a>. The parent relation <em class="rfc2119">MUST</em> not contain cycles: it is tree-shaped with a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-9">logical view</a> as its root. The transitive parents of a <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-8">field</a>, i.e., the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-9">field</a>'s parent, the parent of the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-10">field</a>'s parent, etcetera, are fittingly called the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-11">field</a>'s <dfn id="dfn-ancestors" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn" class="respec-offending-element" title="Found definition for &quot;ancestors&quot;, but nothing links to it. This is usually a spec bug!">ancestors</dfn>. </p>
-</section><section id="field-names"><div class="header-wrapper"><h3 id="fieldnames"><bdi class="secno">4.2 </bdi>Field names</h3><a class="self-link" href="#fieldnames" aria-label="Permalink for Section 4.2"></a></div><p>A <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-12">field</a> <em class="rfc2119">MUST</em> have a <dfn id="dfn-declared-name" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">declared name</dfn> that is an alphanumerical string. Fields with the same <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-2">parent</a> <em class="rfc2119">MUST</em> have different declared names. 
-We distinguish between the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-13">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-2">declared name</a> and the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-14">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-absolute-name" class="internalDFN" id="ref-for-dfn-absolute-name-1">absolute name</a>. 
-If a <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-15">field</a>'s parent is another <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-16">field</a>, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-17">field</a>'s <dfn id="dfn-absolute-name" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">absolute name</dfn> is the concatenation of the name of the parent <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-18">field</a>, a dot <code>.</code>, and the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-19">field</a>'s declared name. 
+</section><section id="field-names"><div class="header-wrapper"><h3 id="fieldnames"><bdi class="secno">4.2 </bdi>Field names</h3><a class="self-link" href="#fieldnames" aria-label="Permalink for Section 4.2"></a></div><p>A <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-12">field</a> <em class="rfc2119">MUST</em> have a <dfn id="dfn-declared-name" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">declared name</dfn> that is an alphanumerical string. Fields with the same <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-2">parent</a> <em class="rfc2119">MUST</em> have different declared names.
+We distinguish between the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-13">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-2">declared name</a> and the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-14">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-absolute-name" class="internalDFN" id="ref-for-dfn-absolute-name-1">absolute name</a>.
+If a <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-15">field</a>'s parent is another <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-16">field</a>, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-17">field</a>'s <dfn id="dfn-absolute-name" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">absolute name</dfn> is the concatenation of the name of the parent <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-18">field</a>, a dot <code>.</code>, and the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-19">field</a>'s declared name.
 Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-20">field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-absolute-name" class="internalDFN" id="ref-for-dfn-absolute-name-2">absolute name</a> equals its <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-3">declared name</a>.  </p>
 <aside class="example" id="ex-fieldnames"><div class="marker">
     <a class="self-link" href="#ex-fieldnames">Example<bdi> 5</bdi></a>
@@ -926,7 +926,7 @@ Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="inte
   <span class="hljs-symbol">rml:source</span> <span class="hljs-symbol">:jsonFile</span> ;
   <span class="hljs-symbol">rml:referenceFormulation</span> <span class="hljs-symbol">rml:JSONPath</span> ;
   <span class="hljs-symbol">rml:iterator</span> <span class="hljs-string">"$.people[*]"</span> .
-  
+
 <span class="hljs-symbol">:jsonView</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalView</span> ;
   <span class="hljs-symbol">rml:viewOn</span> <span class="hljs-symbol">:jsonSource</span> ;
   <span class="hljs-symbol">rml:field</span> [
@@ -1018,12 +1018,12 @@ Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="inte
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item"</span> ;
     <span class="hljs-symbol">rml:iterator</span> <span class="hljs-string">"$.items[*]"</span> ;
     <span class="hljs-symbol">rml:field</span> [
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"type"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"$.type"</span> ;
     ] ;
     <span class="hljs-symbol">rml:field</span> [
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"weight"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"$.weight"</span> ;
     ] ;
@@ -1036,7 +1036,7 @@ Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="inte
 <table>
     <tbody><tr>
         <th><u>#</u></th>
-        <th>&lt;it&gt;</th>   
+        <th>&lt;it&gt;</th>
         <th><u>name.#</u></th>
         <th><u>name</u></th>
         <th><u>item.#</u></th>
@@ -1044,7 +1044,7 @@ Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="inte
         <th><u>item.type.#</u></th>
         <th><u>item.type</u></th>
         <th><u>item.weight.#</u></th>
-        <th><u>item.weight</u></th> 
+        <th><u>item.weight</u></th>
     </tr>
     <tr>
         <td>0</td>
@@ -1067,7 +1067,7 @@ Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="inte
         <td>0</td>
         <td>sword</td>
         <td>0</td>
-        <td>1500</td> 
+        <td>1500</td>
     </tr>
     <tr>
     <td>0</td>
@@ -1121,9 +1121,9 @@ Otherwise, the <a data-link-type="dfn|abstract-op" href="#dfn-field" class="inte
 
 </aside>
 
-</section><section id="field-reference-formulations"><div class="header-wrapper"><h3 id="fieldreferenceformulations"><bdi class="secno">4.4 </bdi>Field reference formulations</h3><a class="self-link" href="#fieldreferenceformulations" aria-label="Permalink for Section 4.4"></a></div><p>For the evaluation of the expression of an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-4">expression field</a> (<code>rml:ExpressionField</code>) on the records of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-4">parent</a>, the parent's <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> is used. 
+</section><section id="field-reference-formulations"><div class="header-wrapper"><h3 id="fieldreferenceformulations"><bdi class="secno">4.4 </bdi>Field reference formulations</h3><a class="self-link" href="#fieldreferenceformulations" aria-label="Permalink for Section 4.4"></a></div><p>For the evaluation of the expression of an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-4">expression field</a> (<code>rml:ExpressionField</code>) on the records of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-4">parent</a>, the parent's <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> is used.
 Consequently, the parent of an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-5">expression field</a> <em class="rfc2119">MUST</em> be an <a href="https://w3id.org/rml/core/spec##dfn-iterable">iterable</a>, i.e. an <a href="https://w3id.org/rml/core/spec##dfn-abstract-logical-source">abstract logical source</a> or <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-5">iterable field</a>.  </p>
-<p>The default <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-6">iterable field</a> (<code>rml:IterableField</code>) is the <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-5">parent</a>. 
+<p>The default <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of an <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-6">iterable field</a> (<code>rml:IterableField</code>) is the <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-5">parent</a>.
 If the <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-7">iterable field</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-6">parent</a> is an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-6">expression field</a>, a <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> <em class="rfc2119">MUST</em> be declared for the <a data-link-type="dfn|abstract-op" href="#dfn-iterable-field" class="internalDFN" id="ref-for-dfn-iterable-field-8">iterable field</a>.
 Declaring a new <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a>, i.e. a <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> that is different from the <a href="https://w3id.org/rml/core/spec##dfn-reference-formulation">reference formulation</a> of the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-7">parent</a>, is only allowed when the field's <a data-link-type="dfn|abstract-op" href="#dfn-parent" class="internalDFN" id="ref-for-dfn-parent-8">parent</a> is an <a data-link-type="dfn|abstract-op" href="#dfn-expression-field" class="internalDFN" id="ref-for-dfn-expression-field-7">expression field</a>. </p>
 <aside class="example" id="ex-mixed-format-json-csv"><div class="marker">
@@ -1132,8 +1132,8 @@ Declaring a new <a href="https://w3id.org/rml/core/spec##dfn-reference-formulati
 
 <p>In this example a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-12">logical view</a> is defined on a <a href="https://w3id.org/rml/core/spec#dfn-logical-source">logical source</a> with reference formulation <code>rml:JSONPath</code>.
 The <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-28">field</a> with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-7">declared name</a> "items" is evaluated using this <a href="https://w3id.org/rml/core/spec#dfn-reference-formulation">reference formulation</a>.
-The nested <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-29">field</a> with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-8">declared name</a> "item" has a declared <a href="https://w3id.org/rml/core/spec#dfn-reference-formulation">reference formulation</a> <code>rml:CSV</code> and CSV row as implicit iterator. 
-Its records are a sequence of logical iterations defined by its iterator. 
+The nested <a data-link-type="dfn|abstract-op" href="#dfn-field" class="internalDFN" id="ref-for-dfn-field-29">field</a> with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-8">declared name</a> "item" has a declared <a href="https://w3id.org/rml/core/spec#dfn-reference-formulation">reference formulation</a> <code>rml:CSV</code> and CSV row as implicit iterator.
+Its records are a sequence of logical iterations defined by its iterator.
 The nested fields with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-9">declared name</a> "type" and "weight" are evaluated using the reference formulation <code>rml:CSV</code> from their parent field with <a data-link-type="dfn|abstract-op" href="#dfn-declared-name" class="internalDFN" id="ref-for-dfn-declared-name-10">declared name</a> "item".</p>
 <pre><code class="json hljs" aria-busy="false"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"people"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
@@ -1146,7 +1146,7 @@ The nested fields with <a data-link-type="dfn|abstract-op" href="#dfn-declared-n
       <span class="hljs-attr">"items"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"type,weight\nflower,15"</span>
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">]</span>
-<span class="hljs-punctuation">}</span>  
+<span class="hljs-punctuation">}</span>
 </code></pre>
 </aside>
 <aside class="ex-mapping">
@@ -1158,24 +1158,24 @@ The nested fields with <a data-link-type="dfn|abstract-op" href="#dfn-declared-n
 
 <span class="hljs-symbol">:mixedJSONView</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalView</span> ;
   <span class="hljs-symbol">rml:viewOn</span> <span class="hljs-symbol">:mixedJSONSource</span> ;
-  <span class="hljs-symbol">rml:field</span> [ 
+  <span class="hljs-symbol">rml:field</span> [
     <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"items"</span> ;
     <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"$.items"</span> ;
-    <span class="hljs-symbol">rml:field</span> [ 
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:IterableField</span> ; 
+    <span class="hljs-symbol">rml:field</span> [
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:IterableField</span> ;
       <span class="hljs-symbol">rml:referenceFormulation</span> <span class="hljs-symbol">rml:CSV;</span>
-      <span class="hljs-symbol">rml:field</span> [ 
-        <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-symbol">rml:field</span> [
+        <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
         <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"type"</span> ;
         <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"type"</span> ;
       ] ;
-      <span class="hljs-symbol">rml:field</span> [ 
+      <span class="hljs-symbol">rml:field</span> [
         <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField;</span>
         <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"weight"</span> ;
         <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"weight"</span> ;
       ] ;
-    ] ; 
+    ] ;
   ] .
 </code></pre>
 </aside>
@@ -1292,8 +1292,8 @@ The <a data-link-type="dfn|abstract-op" href="#dfn-parent-logical-view" class="i
     <a class="self-link" href="#ex-leftjoin">Example<bdi> 8</bdi></a>
   </div>
 
-<p>In this example a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-15">logical view</a> with fields built with data from the logical source <code>:csvSource</code> is joined with the logical view from <a href="#ex-field-record-sequence" data-matched-text="[[[#ex-field-record-sequence]]]" class="box-ref">Example<bdi> 6</bdi></a>. 
-In case of a left join (as in the example), this results in 4 logical iterations in the logical view. 
+<p>In this example a <a data-link-type="dfn|abstract-op" href="#dfn-logical-view" class="internalDFN" id="ref-for-dfn-logical-view-15">logical view</a> with fields built with data from the logical source <code>:csvSource</code> is joined with the logical view from <a href="#ex-field-record-sequence" data-matched-text="[[[#ex-field-record-sequence]]]" class="box-ref">Example<bdi> 6</bdi></a>.
+In case of a left join (as in the example), this results in 4 logical iterations in the logical view.
 If an inner joins would have been used, the logical view would have only 3 logical iterations. </p>
 <aside class="ex-input">
 
@@ -1309,11 +1309,11 @@ tobias,2005
 <pre><code class="turtle hljs" aria-busy="false"><span class="hljs-symbol">:csvSource</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalSource</span> ;
   <span class="hljs-symbol">rml:source</span> <span class="hljs-symbol">:csvFile</span> ;
   <span class="hljs-symbol">rml:referenceFormulation</span> <span class="hljs-symbol">rml:CSV</span> .
-  
+
 <span class="hljs-symbol">:csvView</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalView</span> ;
   <span class="hljs-symbol">rml:viewOn</span> <span class="hljs-symbol">:csvSource</span> ;
   <span class="hljs-symbol">rml:field</span> [
-    <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+    <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"name"</span> ;
     <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"name"</span> ;
   ] ;
@@ -1327,9 +1327,9 @@ tobias,2005
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
-      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ; 
+      <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_type"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"item.type"</span> ;
     ] ;
@@ -1459,7 +1459,7 @@ tobias,2005
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
       <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_type"</span> ;
@@ -1581,7 +1581,7 @@ tobias,789
     <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
     <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"id"</span> ;
     <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"id"</span> ;
-  ] . 
+  ] .
 
 <span class="hljs-symbol">:csvView</span> <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:LogicalView</span> ;
   <span class="hljs-symbol">rml:viewOn</span> <span class="hljs-symbol">:csvSource</span> ;
@@ -1600,7 +1600,7 @@ tobias,789
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
       <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_type"</span> ;
@@ -1611,13 +1611,13 @@ tobias,789
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"item_weight"</span> ;
       <span class="hljs-symbol">rml:reference</span> <span class="hljs-string">"item.weight"</span> ;
     ] ;
-  ] ; 
+  ] ;
   <span class="hljs-symbol">rml:leftJoin</span> [
     <span class="hljs-symbol">rml:parentLogicalView</span> <span class="hljs-symbol">:additionalCsvView</span> ;
     <span class="hljs-symbol">rml:joinCondition</span> [
       <span class="hljs-symbol">rml:parent</span> <span class="hljs-string">"name"</span> ;
       <span class="hljs-symbol">rml:child</span> <span class="hljs-string">"name"</span> ;
-    ] ; 
+    ] ;
     <span class="hljs-symbol">rml:field</span> [
       <span class="hljs-built_in">a</span> <span class="hljs-symbol">rml:ExpressionField</span> ;
       <span class="hljs-symbol">rml:fieldName</span> <span class="hljs-string">"id"</span> ;
@@ -1679,7 +1679,7 @@ tobias,789
 <pre><code class="json hljs" aria-busy="false">
 {...}
 </code></pre>
-</td>        
+</td>
         <td>0</td>
         <td>shield</td>
         <td>0</td>
@@ -2016,7 +2016,7 @@ Note that every <a data-link-type="dfn|abstract-op" href="#dfn-foreignkey-annota
 
 
 <section id="references" class="appendix"><div class="header-wrapper"><h2 id="a-references"><bdi class="secno">A. </bdi>References</h2><a class="self-link" href="#references" aria-label="Permalink for Appendix A."></a></div><section id="normative-references"><div class="header-wrapper"><h3 id="a-1-normative-references"><bdi class="secno">A.1 </bdi>Normative references</h3><a class="self-link" href="#normative-references" aria-label="Permalink for Appendix A.1"></a></div>
-    
+
     <dl class="bibliography"><dt id="bib-rfc2119">[RFC2119]</dt><dd>
       <a href="https://www.rfc-editor.org/rfc/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a>
     </dd><dt id="bib-rfc8174">[RFC8174]</dt><dd>
@@ -2034,257 +2034,257 @@ Note that every <a data-link-type="dfn|abstract-op" href="#dfn-foreignkey-annota
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view" aria-label="Permalink for definition: logical view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-1" title="§ 3. Logical views">§ 3. Logical views</a> <a href="#ref-for-dfn-logical-view-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-1" title="§ 3. Logical views">§ 3. Logical views</a> <a href="#ref-for-dfn-logical-view-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-3" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-4" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-5" title="Reference 3">(3)</a> <a href="#ref-for-dfn-logical-view-6" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-logical-view-3" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-4" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-5" title="Reference 3">(3)</a> <a href="#ref-for-dfn-logical-view-6" title="Reference 4">(4)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-7" title="§ 4. Fields">§ 4. Fields</a> 
+      <a href="#ref-for-dfn-logical-view-7" title="§ 4. Fields">§ 4. Fields</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-8" title="§ 4.1 Field parents">§ 4.1 Field parents</a> <a href="#ref-for-dfn-logical-view-9" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-8" title="§ 4.1 Field parents">§ 4.1 Field parents</a> <a href="#ref-for-dfn-logical-view-9" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-10" title="§ 4.2 Field names">§ 4.2 Field names</a> 
+      <a href="#ref-for-dfn-logical-view-10" title="§ 4.2 Field names">§ 4.2 Field names</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-11" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-logical-view-11" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-12" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> 
+      <a href="#ref-for-dfn-logical-view-12" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-13" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-logical-view-14" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-13" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-logical-view-14" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-15" title="§ 5.2.1 Left join">§ 5.2.1 Left join</a> 
+      <a href="#ref-for-dfn-logical-view-15" title="§ 5.2.1 Left join">§ 5.2.1 Left join</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-16" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a> 
+      <a href="#ref-for-dfn-logical-view-16" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-17" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-logical-view-17" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-18" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a> 
+      <a href="#ref-for-dfn-logical-view-18" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-19" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-logical-view-19" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-20" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> 
+      <a href="#ref-for-dfn-logical-view-20" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-logical-view-iteration-sequence" aria-label="Links in this document to definition: logical view iteration sequence">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view-iteration-sequence" aria-label="Permalink for definition: logical view iteration sequence. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-iteration-sequence-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-iteration-sequence-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-sequence-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-iteration-sequence-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-iteration-sequence-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-logical-view-iteration-sequence-4" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-sequence-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-logical-view-iteration-sequence-4" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-iteration-sequence-5" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-sequence-5" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-logical-view-iteration" aria-label="Links in this document to definition: logical view iteration">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view-iteration" aria-label="Permalink for definition: logical view iteration. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-iteration-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-iteration-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-iteration-3" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-logical-view-iteration-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-iteration-3" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-iteration-4" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> 
+      <a href="#ref-for-dfn-logical-view-iteration-4" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-record" aria-label="Links in this document to definition: record">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-record" aria-label="Permalink for definition: record. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-record-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-record-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-record-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> 
+      <a href="#ref-for-dfn-record-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a>
     </li><li>
-      <a href="#ref-for-dfn-record-4" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-record-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-record-7" title="Reference 4">(4)</a> <a href="#ref-for-dfn-record-8" title="Reference 5">(5)</a> 
+      <a href="#ref-for-dfn-record-4" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-record-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-record-7" title="Reference 4">(4)</a> <a href="#ref-for-dfn-record-8" title="Reference 5">(5)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-iterable-record" aria-label="Links in this document to definition: iterable record">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-iterable-record" aria-label="Permalink for definition: iterable record. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-iterable-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-iterable-record-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-record-3" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-iterable-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-iterable-record-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-record-3" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-iterable-record-4" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> 
+      <a href="#ref-for-dfn-iterable-record-4" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a>
     </li><li>
-      <a href="#ref-for-dfn-iterable-record-5" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-iterable-record-5" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-expression-record" aria-label="Links in this document to definition: expression record">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-expression-record" aria-label="Permalink for definition: expression record. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-expression-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-expression-record-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-expression-record-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-expression-record-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-record-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-expression-record-4" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-expression-record-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-expression-record-4" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-record-5" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-expression-record-5" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-record-key" aria-label="Links in this document to definition: record key">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-record-key" aria-label="Permalink for definition: record key. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-record-key-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-record-key-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-key-3" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-record-key-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-record-key-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-key-3" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-record-key-4" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-record-key-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-key-6" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-record-key-4" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-record-key-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-record-key-6" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-record-key-7" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-record-key-7" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-index-key" aria-label="Links in this document to definition: index key">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-index-key" aria-label="Permalink for definition: index key. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-index-key-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-index-key-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-index-key-1" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> <a href="#ref-for-dfn-index-key-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-index-key-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-index-key-4" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-index-key-3" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-index-key-4" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-index-key-5" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-index-key-5" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-logical-view-reference" aria-label="Links in this document to definition: logical view reference">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view-reference" aria-label="Permalink for definition: logical view reference. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-reference-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-logical-view-reference-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-reference-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-logical-view-reference-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-reference-3" title="§ 5. Logical view joins">§ 5. Logical view joins</a> 
+      <a href="#ref-for-dfn-logical-view-reference-3" title="§ 5. Logical view joins">§ 5. Logical view joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-referenceable-key" aria-label="Links in this document to definition: referenceable key">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-referenceable-key" aria-label="Permalink for definition: referenceable key. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-referenceable-key-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-referenceable-key-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-referenceable-key-1" title="§ 3.2 Logical view expressions">§ 3.2 Logical view expressions</a> <a href="#ref-for-dfn-referenceable-key-2" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-field" aria-label="Links in this document to definition: field">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-field" aria-label="Permalink for definition: field. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-field-1" title="§ 3. Logical views">§ 3. Logical views</a> <a href="#ref-for-dfn-field-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-field-1" title="§ 3. Logical views">§ 3. Logical views</a> <a href="#ref-for-dfn-field-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-3" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a> 
+      <a href="#ref-for-dfn-field-3" title="§ 3.1 Logical view iterator">§ 3.1 Logical view iterator</a>
     </li><li>
-      <a href="#ref-for-dfn-field-4" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-field-5" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-field-4" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-field-5" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-6" title="§ 4.1 Field parents">§ 4.1 Field parents</a> <a href="#ref-for-dfn-field-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-9" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-10" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-11" title="Reference 6">(6)</a> 
+      <a href="#ref-for-dfn-field-6" title="§ 4.1 Field parents">§ 4.1 Field parents</a> <a href="#ref-for-dfn-field-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-9" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-10" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-11" title="Reference 6">(6)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-12" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-field-13" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-14" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-15" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-16" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-17" title="Reference 6">(6)</a> <a href="#ref-for-dfn-field-18" title="Reference 7">(7)</a> <a href="#ref-for-dfn-field-19" title="Reference 8">(8)</a> <a href="#ref-for-dfn-field-20" title="Reference 9">(9)</a> <a href="#ref-for-dfn-field-21" title="Reference 10">(10)</a> 
+      <a href="#ref-for-dfn-field-12" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-field-13" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-14" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-15" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-16" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-17" title="Reference 6">(6)</a> <a href="#ref-for-dfn-field-18" title="Reference 7">(7)</a> <a href="#ref-for-dfn-field-19" title="Reference 8">(8)</a> <a href="#ref-for-dfn-field-20" title="Reference 9">(9)</a> <a href="#ref-for-dfn-field-21" title="Reference 10">(10)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-22" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-field-23" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-24" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-25" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-26" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-27" title="Reference 6">(6)</a> 
+      <a href="#ref-for-dfn-field-22" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-field-23" title="Reference 2">(2)</a> <a href="#ref-for-dfn-field-24" title="Reference 3">(3)</a> <a href="#ref-for-dfn-field-25" title="Reference 4">(4)</a> <a href="#ref-for-dfn-field-26" title="Reference 5">(5)</a> <a href="#ref-for-dfn-field-27" title="Reference 6">(6)</a>
     </li><li>
-      <a href="#ref-for-dfn-field-28" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-field-29" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-field-28" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-field-29" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-expression-field" aria-label="Links in this document to definition: expression field">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-expression-field" aria-label="Permalink for definition: expression field. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-expression-field-1" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-expression-field-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-expression-field-1" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-expression-field-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-field-3" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-expression-field-3" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-field-4" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-expression-field-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-expression-field-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-expression-field-7" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-expression-field-4" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-expression-field-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-expression-field-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-expression-field-7" title="Reference 4">(4)</a>
     </li><li>
-      <a href="#ref-for-dfn-expression-field-8" title="§ 5. Logical view joins">§ 5. Logical view joins</a> 
+      <a href="#ref-for-dfn-expression-field-8" title="§ 5. Logical view joins">§ 5. Logical view joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-iterable-field" aria-label="Links in this document to definition: iterable field">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-iterable-field" aria-label="Permalink for definition: iterable field. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-iterable-field-1" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-iterable-field-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-field-3" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-iterable-field-1" title="§ 4. Fields">§ 4. Fields</a> <a href="#ref-for-dfn-iterable-field-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-field-3" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-iterable-field-4" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-iterable-field-4" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-iterable-field-5" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-iterable-field-6" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-field-7" title="Reference 3">(3)</a> <a href="#ref-for-dfn-iterable-field-8" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-iterable-field-5" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-iterable-field-6" title="Reference 2">(2)</a> <a href="#ref-for-dfn-iterable-field-7" title="Reference 3">(3)</a> <a href="#ref-for-dfn-iterable-field-8" title="Reference 4">(4)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-parent" aria-label="Links in this document to definition: parent">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-parent" aria-label="Permalink for definition: parent. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-parent-1" title="§ 4. Fields">§ 4. Fields</a> 
+      <a href="#ref-for-dfn-parent-1" title="§ 4. Fields">§ 4. Fields</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-2" title="§ 4.2 Field names">§ 4.2 Field names</a> 
+      <a href="#ref-for-dfn-parent-2" title="§ 4.2 Field names">§ 4.2 Field names</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-3" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-parent-3" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-4" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-parent-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-parent-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-parent-7" title="Reference 4">(4)</a> <a href="#ref-for-dfn-parent-8" title="Reference 5">(5)</a> 
+      <a href="#ref-for-dfn-parent-4" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-parent-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-parent-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-parent-7" title="Reference 4">(4)</a> <a href="#ref-for-dfn-parent-8" title="Reference 5">(5)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-ancestors" aria-label="Links in this document to definition: ancestors">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-ancestors" aria-label="Permalink for definition: ancestors. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
@@ -2294,280 +2294,280 @@ Note that every <a data-link-type="dfn|abstract-op" href="#dfn-foreignkey-annota
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-declared-name" aria-label="Permalink for definition: declared name. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-declared-name-1" title="§ 4. Fields">§ 4. Fields</a> 
+      <a href="#ref-for-dfn-declared-name-1" title="§ 4. Fields">§ 4. Fields</a>
     </li><li>
-      <a href="#ref-for-dfn-declared-name-2" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-declared-name-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-declared-name-4" title="Reference 3">(3)</a> <a href="#ref-for-dfn-declared-name-5" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-declared-name-2" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-declared-name-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-declared-name-4" title="Reference 3">(3)</a> <a href="#ref-for-dfn-declared-name-5" title="Reference 4">(4)</a>
     </li><li>
-      <a href="#ref-for-dfn-declared-name-6" title="§ 4.3 Field records">§ 4.3 Field records</a> 
+      <a href="#ref-for-dfn-declared-name-6" title="§ 4.3 Field records">§ 4.3 Field records</a>
     </li><li>
-      <a href="#ref-for-dfn-declared-name-7" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-declared-name-8" title="Reference 2">(2)</a> <a href="#ref-for-dfn-declared-name-9" title="Reference 3">(3)</a> <a href="#ref-for-dfn-declared-name-10" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-declared-name-7" title="§ 4.4 Field reference formulations">§ 4.4 Field reference formulations</a> <a href="#ref-for-dfn-declared-name-8" title="Reference 2">(2)</a> <a href="#ref-for-dfn-declared-name-9" title="Reference 3">(3)</a> <a href="#ref-for-dfn-declared-name-10" title="Reference 4">(4)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-absolute-name" aria-label="Links in this document to definition: absolute name">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-absolute-name" aria-label="Permalink for definition: absolute name. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-absolute-name-1" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-absolute-name-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-absolute-name-1" title="§ 4.2 Field names">§ 4.2 Field names</a> <a href="#ref-for-dfn-absolute-name-2" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-parent-records" aria-label="Links in this document to definition: parent records">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-parent-records" aria-label="Permalink for definition: parent records. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-parent-records-1" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-parent-records-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-parent-records-1" title="§ 4.3 Field records">§ 4.3 Field records</a> <a href="#ref-for-dfn-parent-records-2" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-logical-view-join" aria-label="Links in this document to definition: logical view join">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-logical-view-join" aria-label="Permalink for definition: logical view join. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-logical-view-join-1" title="§ 3. Logical views">§ 3. Logical views</a> 
+      <a href="#ref-for-dfn-logical-view-join-1" title="§ 3. Logical views">§ 3. Logical views</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-join-2" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-logical-view-join-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-join-4" title="Reference 3">(3)</a> 
+      <a href="#ref-for-dfn-logical-view-join-2" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-logical-view-join-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-logical-view-join-4" title="Reference 3">(3)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-join-5" title="§ 5.1 Join types">§ 5.1 Join types</a> <a href="#ref-for-dfn-logical-view-join-6" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-logical-view-join-5" title="§ 5.1 Join types">§ 5.1 Join types</a> <a href="#ref-for-dfn-logical-view-join-6" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-logical-view-join-7" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a> 
+      <a href="#ref-for-dfn-logical-view-join-7" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-parent-logical-view" aria-label="Links in this document to definition: parent logical view">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-parent-logical-view" aria-label="Permalink for definition: parent logical view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-parent-logical-view-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-parent-logical-view-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-parent-logical-view-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a> <a href="#ref-for-dfn-parent-logical-view-2" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-logical-view-3" title="§ 5.1 Join types">§ 5.1 Join types</a> 
+      <a href="#ref-for-dfn-parent-logical-view-3" title="§ 5.1 Join types">§ 5.1 Join types</a>
     </li><li>
-      <a href="#ref-for-dfn-parent-logical-view-4" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a> 
+      <a href="#ref-for-dfn-parent-logical-view-4" title="§ 5.2.3 Two left joins">§ 5.2.3 Two left joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-child-logical-view" aria-label="Links in this document to definition: child logical view">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-child-logical-view" aria-label="Permalink for definition: child logical view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-child-logical-view-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a> 
+      <a href="#ref-for-dfn-child-logical-view-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a>
     </li><li>
-      <a href="#ref-for-dfn-child-logical-view-2" title="§ 5.1 Join types">§ 5.1 Join types</a> <a href="#ref-for-dfn-child-logical-view-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-child-logical-view-2" title="§ 5.1 Join types">§ 5.1 Join types</a> <a href="#ref-for-dfn-child-logical-view-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-join-property" aria-label="Links in this document to definition: join property">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-join-property" aria-label="Permalink for definition: join property. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-join-property-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a> 
+      <a href="#ref-for-dfn-join-property-1" title="§ 5. Logical view joins">§ 5. Logical view joins</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-left-join" aria-label="Links in this document to definition: left join">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-left-join" aria-label="Permalink for definition: left join. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-left-join-1" title="§ 5.1 Join types">§ 5.1 Join types</a> 
+      <a href="#ref-for-dfn-left-join-1" title="§ 5.1 Join types">§ 5.1 Join types</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-inner-join" aria-label="Links in this document to definition: inner join">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-inner-join" aria-label="Permalink for definition: inner join. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-inner-join-1" title="§ 5.1 Join types">§ 5.1 Join types</a> 
+      <a href="#ref-for-dfn-inner-join-1" title="§ 5.1 Join types">§ 5.1 Join types</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-structural-annotations" aria-label="Links in this document to definition: Structural annotations">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-structural-annotations" aria-label="Permalink for definition: Structural annotations. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-structural-annotations-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> <a href="#ref-for-dfn-structural-annotations-2" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-structural-annotations-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> <a href="#ref-for-dfn-structural-annotations-2" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-on-fields" aria-label="Links in this document to definition: on fields">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-on-fields" aria-label="Permalink for definition: on fields. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-on-fields-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-on-fields-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-2" title="§ 6.2 IriSafe">§ 6.2 IriSafe</a> 
+      <a href="#ref-for-dfn-on-fields-2" title="§ 6.2 IriSafe">§ 6.2 IriSafe</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-3" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a> 
+      <a href="#ref-for-dfn-on-fields-3" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-4" title="§ 6.4 Unique">§ 6.4 Unique</a> 
+      <a href="#ref-for-dfn-on-fields-4" title="§ 6.4 Unique">§ 6.4 Unique</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-5" title="§ 6.5 NotNull">§ 6.5 NotNull</a> 
+      <a href="#ref-for-dfn-on-fields-5" title="§ 6.5 NotNull">§ 6.5 NotNull</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-6" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> <a href="#ref-for-dfn-on-fields-7" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-on-fields-6" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> <a href="#ref-for-dfn-on-fields-7" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-on-fields-8" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> 
+      <a href="#ref-for-dfn-on-fields-8" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-irisafe-annotation" aria-label="Links in this document to definition: IriSafe structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-irisafe-annotation" aria-label="Permalink for definition: IriSafe structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-irisafe-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-irisafe-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-primarykey-annotation" aria-label="Links in this document to definition: PrimaryKey structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-primarykey-annotation" aria-label="Permalink for definition: PrimaryKey structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-primarykey-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-primarykey-annotation-2" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-2" title="§ 6.3 PrimaryKey">§ 6.3 PrimaryKey</a>
     </li><li>
-      <a href="#ref-for-dfn-primarykey-annotation-3" title="§ 6.4 Unique">§ 6.4 Unique</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-3" title="§ 6.4 Unique">§ 6.4 Unique</a>
     </li><li>
-      <a href="#ref-for-dfn-primarykey-annotation-4" title="§ 6.5 NotNull">§ 6.5 NotNull</a> 
+      <a href="#ref-for-dfn-primarykey-annotation-4" title="§ 6.5 NotNull">§ 6.5 NotNull</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-unique-annotation" aria-label="Links in this document to definition: Unique structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-unique-annotation" aria-label="Permalink for definition: Unique structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-unique-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-unique-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-unique-annotation-2" title="§ 6.4 Unique">§ 6.4 Unique</a> <a href="#ref-for-dfn-unique-annotation-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-unique-annotation-2" title="§ 6.4 Unique">§ 6.4 Unique</a> <a href="#ref-for-dfn-unique-annotation-3" title="Reference 2">(2)</a>
     </li><li>
-      <a href="#ref-for-dfn-unique-annotation-4" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-unique-annotation-4" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-notnull-annotation" aria-label="Links in this document to definition: NotNull structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-notnull-annotation" aria-label="Permalink for definition: NotNull structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-notnull-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-notnull-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-notnull-annotation-2" title="§ 6.5 NotNull">§ 6.5 NotNull</a> <a href="#ref-for-dfn-notnull-annotation-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-notnull-annotation-2" title="§ 6.5 NotNull">§ 6.5 NotNull</a> <a href="#ref-for-dfn-notnull-annotation-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-foreignkey-annotation" aria-label="Links in this document to definition: ForeignKey structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-foreignkey-annotation" aria-label="Permalink for definition: ForeignKey structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-foreignkey-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-foreignkey-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-foreignkey-annotation-2" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-foreignkey-annotation-2" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-foreignkey-annotation-3" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-foreignkey-annotation-4" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-foreignkey-annotation-3" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-foreignkey-annotation-4" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-target-view" aria-label="Links in this document to definition: target view">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-target-view" aria-label="Permalink for definition: target view. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-target-view-1" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-target-view-1" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-target-view-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-target-view-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-target-view-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-target-view-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-target-fields" aria-label="Links in this document to definition: target fields">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-target-fields" aria-label="Permalink for definition: target fields. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-target-fields-1" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a> 
+      <a href="#ref-for-dfn-target-fields-1" title="§ 6.6 ForeignKey">§ 6.6 ForeignKey</a>
     </li><li>
-      <a href="#ref-for-dfn-target-fields-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> 
+      <a href="#ref-for-dfn-target-fields-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a>
     </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-inclusion-annotation" aria-label="Links in this document to definition: Inclusion structural annotation">
       <span class="caret"></span>
       <div>
         <a class="self-link" href="#dfn-inclusion-annotation" aria-label="Permalink for definition: Inclusion structural annotation. Activate to close this dialog.">Permalink</a>
-         
+
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-inclusion-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a> 
+      <a href="#ref-for-dfn-inclusion-annotation-1" title="§ 6. Structural Annotations">§ 6. Structural Annotations</a>
     </li><li>
-      <a href="#ref-for-dfn-inclusion-annotation-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-inclusion-annotation-3" title="Reference 2">(2)</a> 
+      <a href="#ref-for-dfn-inclusion-annotation-2" title="§ 6.7 Inclusion">§ 6.7 Inclusion</a> <a href="#ref-for-dfn-inclusion-annotation-3" title="Reference 2">(2)</a>
     </li>
   </ul>
     </div><script id="respec-highlight-vars">(() => {


### PR DESCRIPTION
## What's changed
<!-- Give a concise description of the change -->
Dylan informed that there were no intentions to secure a redirect to [https://w3id.org/rml/lv/spec/](https://w3id.org/rml/lv/spec/20250114/): publication URI of spec adapted to https://kg-construct.github.io/rml-lv/spec/docs/

## Issue reference
<!-- For example: -->
<!-- Fixes #{ISSUE}. -->
<!-- Resolves #{ISSUE}. -->
