### PR TITLE
Replacing SPARQL-based constraints to a SHACL-core version

### DIFF
--- a/shapes/lv.ttl
+++ b/shapes/lv.ttl
@@ -333,29 +333,18 @@ rmlsh:InclusionAnnotationShape a sh:NodeShape;
 rmlsh:parentCyclesShape a sh:NodeShape ;
     sh:targetSubjectsOf rml:viewOn ;
     sh:targetSubjectsOf rml:field ;
-    sh:sparql [
-        a sh:SPARQLConstraint ;
+    sh:property [
         sh:message "There must be no cycles via rml:viewOn or rml:Field." ;
-        sh:select """
-            PREFIX rml: <http://w3id.org/rml/>
-            SELECT ?this
-            WHERE {
-              ?this (rml:viewOn|rml:field)+ ?this .
-            }
-        """ ;
+        sh:path [ sh:zeroOrMorePath [ sh:alternativePath ( [ sh:inversePath rml:viewOn ] [ sh:inversePath rml:field ] ) ] ] ;
+        sh:disjoint rml:viewOn ;
+        sh:disjoint rml:field ;
     ] .
 
 rmlsh:joinCyclesShape a sh:NodeShape ;
     sh:targetSubjectsOf rml:viewOn ;
-    sh:sparql [
-        a sh:SPARQLConstraint ;
+    sh:property [
         sh:message "There must be no cycles via rml:viewOn and rml:leftJoin or rml:innerJoin." ;
-        sh:select """
-            PREFIX rml: <http://w3id.org/rml/>
-            SELECT ?this
-            WHERE {
-              ?this a rml:LogicalView .
-              ?this ((rml:leftJoin|rml:innerJoin)/rml:parentLogicalView)+ ?this .
-            }
-        """ ;
+        sh:path ( [ sh:zeroOrMorePath ( [ sh:inversePath rml:parentLogicalView ] [ sh:alternativePath ( [ sh:inversePath rml:leftJoin ] [ sh:inversePath rml:innerJoin ] ) ] ) ] [ sh:inversePath rml:parentLogicalView ] ) ;
+        sh:disjoint rml:leftJoin ;
+        sh:disjoint rml:innerJoin ;
     ] .


### PR DESCRIPTION
# Replacing SPARQL-based constraints to a SHACL-core version rmlsh:parentCyclesShape and rmlsh:joinCyclesShape to a SHACL-core version

## What's changed
`rmlsh:parentCyclesShape` and `rmlsh:joinCyclesShape` in `shapes/lv.ttl` previously used `sh:sparql`/`SPARQLConstraintComponent` to detect cycles via `rml:viewOn`/`rml:field` and `rml:leftJoin`/`rml:innerJoin`. This replaces both with plain SHACL-core property paths (`sh:zeroOrMorePath`, `sh:alternativePath`, `sh:inversePath`) combined with `sh:disjoint`, so cycle detection no longer requires SHACL-SPARQL support from the validating engine.

Verified equivalent to the SPARQL version on RMLLVTC0008a-d using both pySHACL and TopBraid/SHACL.